### PR TITLE
#308 #309 Reflection of the review pointed out

### DIFF
--- a/src/main/java/io/personium/core/PersoniumCoreLog.java
+++ b/src/main/java/io/personium/core/PersoniumCoreLog.java
@@ -76,6 +76,7 @@ public final class PersoniumCoreLog {
 
     /**
      * Authentication related.
+     * Common for authentication and authorization.
      */
     public static class Auth {
         /**
@@ -103,34 +104,40 @@ public final class PersoniumCoreLog {
          * {0}: Detailed message
          */
         public static final PersoniumCoreLog UNSUPPORTED_ACCOUNT_GRANT_TYPE = create("PL-AU-0005");
+    }
+
+    /**
+     * Authentication.
+     */
+    public static class Authn {
         /**
          * Authentication failed. No such account.
          * {0}: URL
          * {1}: IP address
          * {2}: User ID(username)
          */
-        public static final PersoniumCoreLog AUTHN_FAILED_NO_SUCH_ACCOUNT = create("PL-AU-0006");
+        public static final PersoniumCoreLog FAILED_NO_SUCH_ACCOUNT = create("PL-AN-0001");
         /**
          * Authentication failed. Consequtive authentication trial before valid authentication interval.
          * {0}: URL
          * {1}: IP address
          * {2}: User ID(username)
          */
-        public static final PersoniumCoreLog AUTHN_FAILED_BEFORE_AUTHENTICATION_INTERVAL = create("PL-AU-0007");
+        public static final PersoniumCoreLog FAILED_BEFORE_AUTHENTICATION_INTERVAL = create("PL-AN-0002");
         /**
          * Authentication failed. Account is locked.
          * {0}: URL
          * {1}: IP address
          * {2}: User ID(username)
          */
-        public static final PersoniumCoreLog AUTHN_FAILED_ACCOUNT_IS_LOCKED = create("PL-AU-0008");
+        public static final PersoniumCoreLog FAILED_ACCOUNT_IS_LOCKED = create("PL-AN-0003");
         /**
          * Authentication failed. Incorrect password.
          * {0}: URL
          * {1}: IP address
          * {2}: User ID(username)
          */
-        public static final PersoniumCoreLog AUTHN_FAILED_INCORRECT_PASSWORD = create("PL-AU-0009");
+        public static final PersoniumCoreLog FAILED_INCORRECT_PASSWORD = create("PL-AN-0004");
     }
 
     /**

--- a/src/main/java/io/personium/core/PersoniumUnitConfig.java
+++ b/src/main/java/io/personium/core/PersoniumUnitConfig.java
@@ -131,13 +131,6 @@ public class PersoniumUnitConfig {
     }
 
     /**
-     * Setting around Account.
-     */
-    public static final class Account {
-        // TODO add properties later.
-    }
-
-    /**
      * Setting around Dav.
      */
     public static final class Dav {

--- a/src/main/java/io/personium/core/model/lock/AccountValidAuthnIntervalLockManager.java
+++ b/src/main/java/io/personium/core/model/lock/AccountValidAuthnIntervalLockManager.java
@@ -54,8 +54,8 @@ public abstract class AccountValidAuthnIntervalLockManager extends LockManager {
         try {
             String key = CATEGORY_ACCOUNT_VALID_AUTHENTICATION_INTERVAL + accountId;
             //Confirm Lock of target account
-            Integer lockPublic = singleton.doGetAccountLock(key);
-            return lockPublic != null;
+            long lockPublic = singleton.doGetAccountLock(key);
+            return lockPublic != 0;
         } catch (MemcachedClientException e) {
             throw PersoniumCoreException.Server.SERVER_CONNECTION_ERROR;
         }

--- a/src/main/java/io/personium/core/model/lock/LockManager.java
+++ b/src/main/java/io/personium/core/model/lock/LockManager.java
@@ -59,9 +59,11 @@ public abstract class LockManager {
 
     abstract Boolean doPutReferenceOnlyLock(String fullKey, String value);
 
-    abstract Integer doGetAccountLock(String fullKey);
+    abstract long doGetAccountLock(String fullKey);
 
-    abstract Boolean doPutAccountLock(String fullKey, Integer value, int expired);
+    abstract Boolean doPutAccountLock(String fullKey, long value, int expired);
+
+    abstract long doIncrementAccountLock(String fullKey, int expired);
 
     abstract void doReleaseAccountLock(String fullKey);
 

--- a/src/main/java/io/personium/core/model/lock/MemcachedLockManager.java
+++ b/src/main/java/io/personium/core/model/lock/MemcachedLockManager.java
@@ -53,13 +53,18 @@ class MemcachedLockManager extends LockManager {
     }
 
     @Override
-    Integer doGetAccountLock(String fullKey) {
-        return MemcachedClient.getLockClient().get(fullKey, Integer.class);
+    long doGetAccountLock(String fullKey) {
+        return MemcachedClient.getLockClient().getLongValue(fullKey);
     }
 
     @Override
-    Boolean doPutAccountLock(String fullKey, Integer value, int expired) {
-        return MemcachedClient.getLockClient().put(fullKey, expired, value);
+    Boolean doPutAccountLock(String fullKey, long value, int expired) {
+        return MemcachedClient.getLockClient().createLongValue(fullKey, value, expired);
+    }
+
+    @Override
+    long doIncrementAccountLock(String fullKey, int expired) {
+        return MemcachedClient.getLockClient().incrementLongValue(fullKey, expired);
     }
 
     @Override

--- a/src/main/java/io/personium/core/rs/cell/AuthzEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/AuthzEndPointResource.java
@@ -320,7 +320,7 @@ public class AuthzEndPointResource {
                 //Update lock time of memcached
                 AuthResourceUtils.registIntervalLock(accountId);
                 AuthResourceUtils.countupFailedCount(accountId);
-                PersoniumCoreLog.Auth.AUTHN_FAILED_BEFORE_AUTHENTICATION_INTERVAL.params(
+                PersoniumCoreLog.Authn.FAILED_BEFORE_AUTHENTICATION_INTERVAL.params(
                         requestURIInfo.getRequestUri().toString(), this.ipaddress, username).writeLog();
                 AuthResourceUtils.updateAuthHistoryLastFileWithFailed(cellRsCmp.getDavCmp().getFsPath(), accountId);
                 return returnHtmlForm(responseType, clientId, redirectUri, MSG_INCORRECT_ID_PASS, state, scope);
@@ -332,7 +332,7 @@ public class AuthzEndPointResource {
                 //Update lock time of memcached
                 AuthResourceUtils.registIntervalLock(accountId);
                 AuthResourceUtils.countupFailedCount(accountId);
-                PersoniumCoreLog.Auth.AUTHN_FAILED_ACCOUNT_IS_LOCKED.params(
+                PersoniumCoreLog.Authn.FAILED_ACCOUNT_IS_LOCKED.params(
                         requestURIInfo.getRequestUri().toString(), this.ipaddress, username).writeLog();
                 AuthResourceUtils.updateAuthHistoryLastFileWithFailed(cellRsCmp.getDavCmp().getFsPath(), accountId);
                 return returnHtmlForm(responseType, clientId, redirectUri, MSG_INCORRECT_ID_PASS, state, scope);
@@ -344,7 +344,7 @@ public class AuthzEndPointResource {
                 //Make lock on memcached
                 AuthResourceUtils.registIntervalLock(accountId);
                 AuthResourceUtils.countupFailedCount(accountId);
-                PersoniumCoreLog.Auth.AUTHN_FAILED_INCORRECT_PASSWORD.params(
+                PersoniumCoreLog.Authn.FAILED_INCORRECT_PASSWORD.params(
                         requestURIInfo.getRequestUri().toString(), this.ipaddress, username).writeLog();
                 AuthResourceUtils.updateAuthHistoryLastFileWithFailed(cellRsCmp.getDavCmp().getFsPath(), accountId);
                 return returnHtmlForm(responseType, clientId, redirectUri, MSG_INCORRECT_ID_PASS, state, scope);

--- a/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
@@ -694,7 +694,7 @@ public class TokenEndPointResource {
 
         OEntityWrapper oew = cell.getAccount(username);
         if (oew == null) {
-            PersoniumCoreLog.Auth.AUTHN_FAILED_NO_SUCH_ACCOUNT.params(
+            PersoniumCoreLog.Authn.FAILED_NO_SUCH_ACCOUNT.params(
                     requestURIInfo.getRequestUri().toString(), this.ipaddress, username).writeLog();
             throw PersoniumCoreAuthnException.AUTHN_FAILED.realm(this.cell.getUrl());
         }
@@ -717,7 +717,7 @@ public class TokenEndPointResource {
             AuthResourceUtils.registIntervalLock(accountId);
             AuthResourceUtils.countupFailedCount(accountId);
             AuthResourceUtils.updateAuthHistoryLastFileWithFailed(davRsCmp.getDavCmp().getFsPath(), accountId);
-            PersoniumCoreLog.Auth.AUTHN_FAILED_BEFORE_AUTHENTICATION_INTERVAL.params(
+            PersoniumCoreLog.Authn.FAILED_BEFORE_AUTHENTICATION_INTERVAL.params(
                     requestURIInfo.getRequestUri().toString(), this.ipaddress, username).writeLog();
             throw PersoniumCoreAuthnException.AUTHN_FAILED.realm(this.cell.getUrl());
         }
@@ -729,7 +729,7 @@ public class TokenEndPointResource {
             AuthResourceUtils.registIntervalLock(accountId);
             AuthResourceUtils.countupFailedCount(accountId);
             AuthResourceUtils.updateAuthHistoryLastFileWithFailed(davRsCmp.getDavCmp().getFsPath(), accountId);
-            PersoniumCoreLog.Auth.AUTHN_FAILED_ACCOUNT_IS_LOCKED.params(
+            PersoniumCoreLog.Authn.FAILED_ACCOUNT_IS_LOCKED.params(
                     requestURIInfo.getRequestUri().toString(), this.ipaddress, username).writeLog();
             throw PersoniumCoreAuthnException.AUTHN_FAILED.realm(this.cell.getUrl());
         }
@@ -741,7 +741,7 @@ public class TokenEndPointResource {
             AuthResourceUtils.registIntervalLock(accountId);
             AuthResourceUtils.countupFailedCount(accountId);
             AuthResourceUtils.updateAuthHistoryLastFileWithFailed(davRsCmp.getDavCmp().getFsPath(), accountId);
-            PersoniumCoreLog.Auth.AUTHN_FAILED_INCORRECT_PASSWORD.params(
+            PersoniumCoreLog.Authn.FAILED_INCORRECT_PASSWORD.params(
                     requestURIInfo.getRequestUri().toString(), this.ipaddress, username).writeLog();
             throw PersoniumCoreAuthnException.AUTHN_FAILED.realm(this.cell.getUrl());
         }

--- a/src/main/java/io/personium/core/utils/MemcachedClient.java
+++ b/src/main/java/io/personium/core/utils/MemcachedClient.java
@@ -186,8 +186,19 @@ public class MemcachedClient implements CacheClient {
      * @return Returns true if creation succeeded or already exists, false if it fails
      */
     public Boolean createLongValue(String key, long initValue) {
+        return createLongValue(key, initValue, 0);
+    }
+
+    /**
+     * Create a new object with the specified key.
+     * @param key Cache key
+     * @param initValue Initial value
+     * @param expiresIn lifetime
+     * @return Returns true if creation succeeded or already exists, false if it fails
+     */
+    public Boolean createLongValue(String key, long initValue, int expiresIn) {
         try {
-            long count = this.spyClient.incr(key, 0, initValue);
+            long count = this.spyClient.incr(key, 0, initValue, expiresIn);
             return count == initValue;
         } catch (RuntimeException e) {
             log.info(e.getMessage(), e);
@@ -216,8 +227,18 @@ public class MemcachedClient implements CacheClient {
      * @return Value after increment
      */
     public long incrementLongValue(String key) {
+        return incrementLongValue(key, 0);
+    }
+
+    /**
+     * Increment the value of the specified key.
+     * @param key Cache key
+     * @param expiresIn lifetime
+     * @return Value after increment
+     */
+    public long incrementLongValue(String key, int expiresIn) {
         try {
-            return this.spyClient.incr(key, 1, 1);
+            return this.spyClient.incr(key, 1, 1, expiresIn);
         } catch (RuntimeException e) {
             log.info(e.getMessage(), e);
             throw new MemcachedClientException(e);

--- a/src/main/resources/personium-log-level.properties
+++ b/src/main/resources/personium-log-level.properties
@@ -50,10 +50,12 @@ io.personium.core.loglevel.PR503-DV-0001=info
 io.personium.core.loglevel.PL-AU-0001=info
 io.personium.core.loglevel.PL-AU-0002=info
 io.personium.core.loglevel.PL-AU-0004=info
-io.personium.core.loglevel.PL-AU-0006=info
-io.personium.core.loglevel.PL-AU-0007=info
-io.personium.core.loglevel.PL-AU-0008=info
-io.personium.core.loglevel.PL-AU-0009=info
+
+# Authn
+io.personium.core.loglevel.PL-AN-0001=info
+io.personium.core.loglevel.PL-AN-0002=info
+io.personium.core.loglevel.PL-AN-0003=info
+io.personium.core.loglevel.PL-AN-0004=info
 
 # OIDC
 io.personium.core.loglevel.PL-OI-0001=info

--- a/src/main/resources/personium-messages.properties
+++ b/src/main/resources/personium-messages.properties
@@ -410,10 +410,12 @@ io.personium.core.msg.PL-AU-0002=Token disg error. Reason={0}
 io.personium.core.msg.PL-AU-0003=Root Ca crt setting error. Reason={0}
 io.personium.core.msg.PL-AU-0004=Account is already deleted [name={0}].
 io.personium.core.msg.PL-AU-0005=Requested type={0} not available in account Name={1}.
-io.personium.core.msg.PL-AU-0006=Authentication failed. No such account. [{0}] [{1}] [{2}]
-io.personium.core.msg.PL-AU-0007=Authentication failed. Consequtive authentication trial before valid authentication interval. [{0}] [{1}] [{2}]
-io.personium.core.msg.PL-AU-0008=Authentication failed. Account is locked. [{0}] [{1}] [{2}]
-io.personium.core.msg.PL-AU-0009=Authentication failed. Incorrect password. [{0}] [{1}] [{2}]
+
+#Authn
+io.personium.core.msg.PL-AN-0001=Authentication failed. No such account. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0002=Authentication failed. Consequtive authentication trial before valid authentication interval. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0003=Authentication failed. Account is locked. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0004=Authentication failed. Incorrect password. [{0}] [{1}] [{2}]
 
 # OIDC
 io.personium.core.msg.PL-OI-0001=No such account. Name={0}

--- a/src/test/java/io/personium/core/model/lock/AccountLockManagerTest.java
+++ b/src/test/java/io/personium/core/model/lock/AccountLockManagerTest.java
@@ -78,18 +78,18 @@ public class AccountLockManagerTest {
     @Test
     public void countup_failed_count() {
         // countup.
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(0));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(0L));
         AccountLockManager.countupFailedCount("account_1");
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(1));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(1L));
         AccountLockManager.countupFailedCount("account_1");
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(2));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(2L));
         AccountLockManager.countupFailedCount("account_1");
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(3));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(3L));
 
         // countup ohter account failed count.
         AccountLockManager.countupFailedCount("account_2");
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(3));
-        assertThat(AccountLockManager.getFailedCount("account_2"), is(1));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(3L));
+        assertThat(AccountLockManager.getFailedCount("account_2"), is(1L));
     }
 
     /**
@@ -129,25 +129,25 @@ public class AccountLockManagerTest {
         AccountLockManager.countupFailedCount("account_1");
         AccountLockManager.countupFailedCount("account_1");
         assertThat(AccountLockManager.isLockedAccount("account_1"), is(true));
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(5));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(5L));
         AccountLockManager.countupFailedCount("account_2");
         AccountLockManager.countupFailedCount("account_2");
         AccountLockManager.countupFailedCount("account_2");
         assertThat(AccountLockManager.isLockedAccount("account_2"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_2"), is(3));
+        assertThat(AccountLockManager.getFailedCount("account_2"), is(3L));
 
         // release account lock.
         AccountLockManager.releaseAccountLock("account_1");
         assertThat(AccountLockManager.isLockedAccount("account_1"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(0));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(0L));
         assertThat(AccountLockManager.isLockedAccount("account_2"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_2"), is(3));
+        assertThat(AccountLockManager.getFailedCount("account_2"), is(3L));
 
         AccountLockManager.releaseAccountLock("account_2");
         assertThat(AccountLockManager.isLockedAccount("account_1"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(0));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(0L));
         assertThat(AccountLockManager.isLockedAccount("account_2"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_2"), is(0));
+        assertThat(AccountLockManager.getFailedCount("account_2"), is(0L));
     }
 
     /**
@@ -162,20 +162,20 @@ public class AccountLockManagerTest {
         AccountLockManager.countupFailedCount("account_1");
         AccountLockManager.countupFailedCount("account_1");
         assertThat(AccountLockManager.isLockedAccount("account_1"), is(true));
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(5));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(5L));
         AccountLockManager.countupFailedCount("account_2");
         AccountLockManager.countupFailedCount("account_2");
         AccountLockManager.countupFailedCount("account_2");
         assertThat(AccountLockManager.isLockedAccount("account_2"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_2"), is(3));
+        assertThat(AccountLockManager.getFailedCount("account_2"), is(3L));
 
         // wait account lock expiration time (s).
         Thread.sleep(1000 * AccountLockManager.accountLockTime + 1);
 
         // check ralease account lock and reset failed count.
         assertThat(AccountLockManager.isLockedAccount("account_1"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_1"), is(0));
+        assertThat(AccountLockManager.getFailedCount("account_1"), is(0L));
         assertThat(AccountLockManager.isLockedAccount("account_2"), is(false));
-        assertThat(AccountLockManager.getFailedCount("account_2"), is(0));
+        assertThat(AccountLockManager.getFailedCount("account_2"), is(0L));
     }
 }

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthAccountLockTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthAccountLockTest.java
@@ -137,19 +137,19 @@ public class AuthAccountLockTest extends PersoniumTest {
     @Test
     public final void lock_and_unlock() {
         // before account lock.
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
 
         // authentication failed repeatedly, account is locked.
         for (int i = 0; i < TEST_ACCOUNTLOCK_COUNT; i++) {
-            requestAuthorization(TEST_CELL, TEST_ACCOUNT1, "error", HttpStatus.SC_BAD_REQUEST);
+            requestAuthentication(TEST_CELL, TEST_ACCOUNT1, "error", HttpStatus.SC_BAD_REQUEST);
         }
         AuthTestCommon.waitForIntervalLock();
-        TResponse passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_BAD_REQUEST);
+        TResponse passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_BAD_REQUEST);
         String body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
 
         // other account not locked.
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT2, TEST_PASSWORD, HttpStatus.SC_OK);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT2, TEST_PASSWORD, HttpStatus.SC_OK);
 
         // wait account lock expiration time (s). accountlock is released .
         try {
@@ -157,7 +157,7 @@ public class AuthAccountLockTest extends PersoniumTest {
         } catch (InterruptedException e) {
             log.debug("");
         }
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
     }
 
     /**
@@ -167,28 +167,28 @@ public class AuthAccountLockTest extends PersoniumTest {
     public final void reset_failed_count() {
         // first authenticated.
         for (int i = 0; i < TEST_ACCOUNTLOCK_COUNT - 1; i++) {
-            requestAuthorization(TEST_CELL, TEST_ACCOUNT1, "error", HttpStatus.SC_BAD_REQUEST);
+            requestAuthentication(TEST_CELL, TEST_ACCOUNT1, "error", HttpStatus.SC_BAD_REQUEST);
         }
         AuthTestCommon.waitForIntervalLock();
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
 
         // seccond authenticated.
         for (int i = 0; i < TEST_ACCOUNTLOCK_COUNT - 1; i++) {
-            requestAuthorization(TEST_CELL, TEST_ACCOUNT1, "error", HttpStatus.SC_BAD_REQUEST);
+            requestAuthentication(TEST_CELL, TEST_ACCOUNT1, "error", HttpStatus.SC_BAD_REQUEST);
         }
         AuthTestCommon.waitForIntervalLock();
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT1, TEST_PASSWORD, HttpStatus.SC_OK);
     }
 
     /**
-     * request authorization.
+     * request authentication.
      * @param cellName cell name
      * @param userName user name
      * @param password password
      * @param code expected status code
      * @return http response
      */
-    private TResponse requestAuthorization(String cellName, String userName, String password, int code) {
+    private TResponse requestAuthentication(String cellName, String userName, String password, int code) {
         TResponse passRes = Http.request("authn/password-cl-c0.txt")
                 .with("remoteCell", cellName)
                 .with("username", userName)

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
@@ -30,8 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.personium.core.auth.OAuth2Helper;
 import io.personium.core.rs.PersoniumCoreApplication;
@@ -52,8 +50,6 @@ import io.personium.test.utils.TResponse;
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({ Unit.class, Integration.class, Regression.class })
 public class AuthHistoryTest extends PersoniumTest {
-
-    private static Logger log = LoggerFactory.getLogger(AuthHistoryTest.class);
 
     /** test cell name. */
     private static final String TEST_CELL = "testcellauthhistory";
@@ -111,9 +107,9 @@ public class AuthHistoryTest extends PersoniumTest {
         requestAuthorization(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         requestAuthorization(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         AuthTestCommon.waitForIntervalLock();
-        Long beforeFirstAuthenticatedTime = new Date().getTime();
+        Long before1stAuthnTime = new Date().getTime();
         TResponse passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
-        Long afterFirstAuthenticatedTime = new Date().getTime();
+        Long after1stAuthnTime = new Date().getTime();
 
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
         assertNull(passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED));
@@ -121,11 +117,11 @@ public class AuthHistoryTest extends PersoniumTest {
 
         // second get token. failed count = 0.
         passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
-        Long afterSecondAuthenticatedTime = new Date().getTime();
+        Long after2ndAuthnTime = new Date().getTime();
 
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
         Long lastAuthenticated = (Long) passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED);
-        assertTrue(beforeFirstAuthenticatedTime <= lastAuthenticated && lastAuthenticated <= afterFirstAuthenticatedTime);
+        assertTrue(before1stAuthnTime <= lastAuthenticated && lastAuthenticated <= after1stAuthnTime);
         assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(0L));
 
         // third get token. failed count = 1.
@@ -135,7 +131,7 @@ public class AuthHistoryTest extends PersoniumTest {
 
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
         lastAuthenticated = (Long) passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED);
-        assertTrue(afterFirstAuthenticatedTime <= lastAuthenticated && lastAuthenticated <= afterSecondAuthenticatedTime);
+        assertTrue(after1stAuthnTime <= lastAuthenticated && lastAuthenticated <= after2ndAuthnTime);
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.FAILED_COUNT));
         assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(1L));
     }
@@ -173,7 +169,7 @@ public class AuthHistoryTest extends PersoniumTest {
     }
 
     /**
-     * request authorization.（__token)
+     * request authorization.
      * @param cellName cell name
      * @param userName user name
      * @param password password

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
@@ -89,7 +89,7 @@ public class AuthHistoryTest extends PersoniumTest {
      */
     @Test
     public final void first_authenticated() {
-        TResponse passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
+        TResponse passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
 
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
         assertNull(passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED));
@@ -103,12 +103,12 @@ public class AuthHistoryTest extends PersoniumTest {
     @Test
     public final void get_last_authenticated() {
         // first get token. failed count = 3.
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         AuthTestCommon.waitForIntervalLock();
         Long before1stAuthnTime = new Date().getTime();
-        TResponse passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
+        TResponse passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
         Long after1stAuthnTime = new Date().getTime();
 
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
@@ -116,7 +116,7 @@ public class AuthHistoryTest extends PersoniumTest {
         assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(3L));
 
         // second get token. failed count = 0.
-        passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
+        passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
         Long after2ndAuthnTime = new Date().getTime();
 
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
@@ -125,9 +125,9 @@ public class AuthHistoryTest extends PersoniumTest {
         assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(0L));
 
         // third get token. failed count = 1.
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         AuthTestCommon.waitForIntervalLock();
-        passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
+        passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
 
         assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
         lastAuthenticated = (Long) passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED);
@@ -144,11 +144,11 @@ public class AuthHistoryTest extends PersoniumTest {
     public final void token_refresh() {
         // first get token.
         Long beforeAuthenticatedTime = new Date().getTime();
-        TResponse passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
+        TResponse passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
         Long afterFirstAuthenticatedTime = new Date().getTime();
 
         // failed get token after first get token.
-        requestAuthorization(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+        requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
 
         // token refresh.
         String refreshToken = (String) passRes.bodyAsJson().get(OAuth2Helper.Key.REFRESH_TOKEN);
@@ -162,21 +162,21 @@ public class AuthHistoryTest extends PersoniumTest {
 
         // get token after refreshed. check last authenticated and failed count.
         AuthTestCommon.waitForIntervalLock();
-        passRes = requestAuthorization(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
+        passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
         Long lastAuthenticated = (Long) passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED);
         assertTrue(beforeAuthenticatedTime <= lastAuthenticated && lastAuthenticated <= afterFirstAuthenticatedTime);
         assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(1L));
     }
 
     /**
-     * request authorization.
+     * request authentication.
      * @param cellName cell name
      * @param userName user name
      * @param password password
      * @param code expected status code
      * @return http response
      */
-    private TResponse requestAuthorization(String cellName, String userName, String password, int code) {
+    private TResponse requestAuthentication(String cellName, String userName, String password, int code) {
         TResponse passRes = Http.request("authn/password-cl-c0.txt")
                 .with("remoteCell", cellName)
                 .with("username", userName)

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthValidIntervalTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthValidIntervalTest.java
@@ -87,13 +87,13 @@ public class AuthValidIntervalTest extends PersoniumTest {
     @Ignore
     public final void パスワード認証失敗後1秒以内に成功する認証をリクエストした場合400が返却されること() {
         // パスワード認証1回目_ 不正なパスワード指定(400エラー(PR400-AN-0017))
-        TResponse passRes = requestAuthorization(TEST_CELL1, "account1",
+        TResponse passRes = requestAuthentication(TEST_CELL1, "account1",
                 "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         String body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
 
         // 1秒以内にパスワード認証(400エラー(PR400-AN-0017))
-        passRes = requestAuthorization(TEST_CELL1, "account1", "password1", HttpStatus.SC_BAD_REQUEST);
+        passRes = requestAuthentication(TEST_CELL1, "account1", "password1", HttpStatus.SC_BAD_REQUEST);
         body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
 
@@ -108,13 +108,13 @@ public class AuthValidIntervalTest extends PersoniumTest {
     @Ignore
     public final void パスワード認証失敗後1秒以内に失敗する認証をリクエストした場合400が返却されること() {
         // パスワード認証1回目_ 不正なパスワード指定(400エラー(PR400-AN-0017))
-        TResponse passRes = requestAuthorization(TEST_CELL1, "account1",
+        TResponse passRes = requestAuthentication(TEST_CELL1, "account1",
                 "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         String body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
 
         // 1秒以内にパスワード認証(400エラー(PR400-AN-0017))
-        passRes = requestAuthorization(TEST_CELL1, "account1", "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+        passRes = requestAuthentication(TEST_CELL1, "account1", "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
 
@@ -127,7 +127,7 @@ public class AuthValidIntervalTest extends PersoniumTest {
     @Test
     public final void パスワード認証失敗後1秒後に成功する認証をリクエストした場合200が返却されること() {
         // パスワード認証1回目_ 不正なパスワード指定(400エラー(PR400-AN-0017))
-        TResponse passRes = requestAuthorization(TEST_CELL1, "account1",
+        TResponse passRes = requestAuthentication(TEST_CELL1, "account1",
                 "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         String body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
@@ -138,7 +138,7 @@ public class AuthValidIntervalTest extends PersoniumTest {
             log.debug("");
         }
         // 1秒後にパスワード認証(認証成功)
-        passRes = requestAuthorization(TEST_CELL1, "account1", "password1", HttpStatus.SC_OK);
+        passRes = requestAuthentication(TEST_CELL1, "account1", "password1", HttpStatus.SC_OK);
         body = (String) passRes.bodyAsJson().get("access_token");
         assertNotNull(body);
     }
@@ -149,7 +149,7 @@ public class AuthValidIntervalTest extends PersoniumTest {
     @Test
     public final void パスワード認証失敗後1秒後に失敗する認証をリクエストした場合400が返却されること() {
         // パスワード認証1回目_ 不正なパスワード指定(400エラー(PR400-AN-0017))
-        TResponse passRes = requestAuthorization(TEST_CELL1, "account1",
+        TResponse passRes = requestAuthentication(TEST_CELL1, "account1",
                 "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         String body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
@@ -161,13 +161,13 @@ public class AuthValidIntervalTest extends PersoniumTest {
         }
 
         // 1秒後にパスワード認証(400エラー(PR400-AN-0017))
-        passRes = requestAuthorization(TEST_CELL1, "account1", "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+        passRes = requestAuthentication(TEST_CELL1, "account1", "dummypassword1", HttpStatus.SC_BAD_REQUEST);
         body = (String) passRes.bodyAsJson().get("error_description");
         assertTrue(body.startsWith("[PR400-AN-0017]"));
         AuthTestCommon.waitForIntervalLock();
     }
 
-    private TResponse requestAuthorization(String cellName, String userName, String password, int code) {
+    private TResponse requestAuthentication(String cellName, String userName, String password, int code) {
         TResponse passRes =
                 Http.request("authn/password-cl-c0.txt")
                         .with("remoteCell", cellName)

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthzAccountLockTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthzAccountLockTest.java
@@ -54,7 +54,7 @@ import io.personium.test.utils.BoxUtils;
 import io.personium.test.utils.CellUtils;
 
 /**
- * account lock test for authz.
+ * account lock test for authorization.
  */
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({ Unit.class, Integration.class, Regression.class })

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthzGetAuthHistoryTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthzGetAuthHistoryTest.java
@@ -31,8 +31,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.personium.core.auth.OAuth2Helper;
 import io.personium.core.rs.PersoniumCoreApplication;
@@ -51,13 +49,11 @@ import io.personium.test.utils.BoxUtils;
 import io.personium.test.utils.CellUtils;
 
 /**
- * test auth history.
+ * test auth history for authorization.
  */
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({ Unit.class, Integration.class, Regression.class })
 public class AuthzGetAuthHistoryTest extends PersoniumTest {
-
-    private static Logger log = LoggerFactory.getLogger(AuthzGetAuthHistoryTest.class);
 
     /** test cell name. */
     private static final String TEST_CELL = "testcellauthzgetauthhistory";
@@ -99,10 +95,10 @@ public class AuthzGetAuthHistoryTest extends PersoniumTest {
 
     /**
      * first authenticated.
-     * @throws PersoniumException
+     * @throws Exception Unexpected exception
      */
     @Test
-    public final void authz_first_authenticated() throws PersoniumException {
+    public final void authz_first_authenticated() throws Exception {
         PersoniumResponse dcRes = requestAuthorization4Authz(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD);
         assertThat(dcRes.getStatusCode()).isEqualTo(HttpStatus.SC_SEE_OTHER);
         Map<String, String> responseMap = parseResponse(dcRes);
@@ -113,18 +109,18 @@ public class AuthzGetAuthHistoryTest extends PersoniumTest {
 
     /**
      * get "last_authenticated" and "failed_count".
-     * @throws PersoniumException
+     * @throws Exception Unexpected exception
      */
     @Test
-    public final void get_last_authenticated() throws PersoniumException {
+    public final void get_last_authenticated() throws Exception {
         // first get token. failed count = 3.
         requestAuthorization4Authz(TEST_CELL, TEST_ACCOUNT, "dummypassword");
         requestAuthorization4Authz(TEST_CELL, TEST_ACCOUNT, "dummypassword");
         requestAuthorization4Authz(TEST_CELL, TEST_ACCOUNT, "dummypassword");
         AuthTestCommon.waitForIntervalLock();
-        Long beforeFirstAuthenticatedTime = new Date().getTime();
+        Long before1stAuthnTime = new Date().getTime();
         PersoniumResponse dcRes = requestAuthorization4Authz(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD);
-        Long afterFirstAuthenticatedTime = new Date().getTime();
+        Long after1stAuthnTime = new Date().getTime();
 
         assertThat(dcRes.getStatusCode()).isEqualTo(HttpStatus.SC_SEE_OTHER);
         Map<String, String> responseMap = parseResponse(dcRes);
@@ -134,13 +130,13 @@ public class AuthzGetAuthHistoryTest extends PersoniumTest {
 
         // second get token. failed count = 0.
         dcRes = requestAuthorization4Authz(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD);
-        Long afterSecondAuthenticatedTime = new Date().getTime();
+        Long after2ndAuthnTime = new Date().getTime();
 
         assertThat(dcRes.getStatusCode()).isEqualTo(HttpStatus.SC_SEE_OTHER);
         responseMap = parseResponse(dcRes);
         assertFalse(responseMap.containsKey(OAuth2Helper.Key.ERROR));
         Long lastAuthenticated = Long.valueOf(responseMap.get(OAuth2Helper.Key.LAST_AUTHENTICATED));
-        assertTrue(beforeFirstAuthenticatedTime <= lastAuthenticated && lastAuthenticated <= afterFirstAuthenticatedTime);
+        assertTrue(before1stAuthnTime <= lastAuthenticated && lastAuthenticated <= after1stAuthnTime);
         assertThat(responseMap.get(OAuth2Helper.Key.FAILED_COUNT)).contains("0");
 
         // third get token. failed count = 1.
@@ -152,12 +148,12 @@ public class AuthzGetAuthHistoryTest extends PersoniumTest {
         responseMap = parseResponse(dcRes);
         assertFalse(responseMap.containsKey(OAuth2Helper.Key.ERROR));
         lastAuthenticated = Long.valueOf(responseMap.get(OAuth2Helper.Key.LAST_AUTHENTICATED));
-        assertTrue(afterFirstAuthenticatedTime <= lastAuthenticated && lastAuthenticated <= afterSecondAuthenticatedTime);
+        assertTrue(after1stAuthnTime <= lastAuthenticated && lastAuthenticated <= after2ndAuthnTime);
         assertThat(responseMap.get(OAuth2Helper.Key.FAILED_COUNT)).contains("1");
     }
 
     /**
-     * request authorization.（__authz)
+     * request authorization.
      * @param cellName cell name
      * @param userName user name
      * @param password password


### PR DESCRIPTION
- Fixed code value of log message
- Fixed the condition of lock execution determination
- Fixed the logic of count up authentication failure count saved in
Memcached.
- Fixed that "authentication" and "authorization" were confused.