### PR TITLE
#315 Support "bind" and "unbind" privileges, #50 Include "inherited" tag

### DIFF
--- a/src/main/java/io/personium/core/model/impl/fs/CellCmpFsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/fs/CellCmpFsImpl.java
@@ -119,6 +119,13 @@ public class CellCmpFsImpl extends DavCmpFsImpl implements CellCmp {
     }
 
     /**
+     * @return URL string of this Cell node.
+     */
+    public String getUrl() {
+        return this.cell.getUrl();
+    }
+
+    /**
      * checks if this cmp is Cell level.
      * @return true if Cell level
      */

--- a/src/main/java/io/personium/core/model/impl/fs/DavCmpFsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/fs/DavCmpFsImpl.java
@@ -892,17 +892,19 @@ public class DavCmpFsImpl implements DavCmp {
             //Even if you acquire the access context of the source, you can get the same Object
             //Therefore, we use the access context of the move destination
             AccessContext ac = davDestination.getDestinationRsCmp().getAccessContext();
+
             //Access control to the destination
             //For the following reasons, access is controlled to the destination after locking.
             //1. Since access to the ES does not occur in the access control, influence on the length of the lock period is small even if executed during locking.
             //2. When performing access control of the move destination before locking, it is necessary to acquire the information of the move destination, and a request to the ES occurs.
-            davDestination.getDestinationRsCmp().getParent().checkAccessContext(ac, BoxPrivilege.WRITE);
-
             File destDir = ((DavCmpFsImpl) davDestination.getDestinationCmp()).fsDir;
             if (!davDestination.getDestinationCmp().exists()) {
+                davDestination.getDestinationRsCmp().getParent().checkAccessContext(ac, BoxPrivilege.BIND);
                 Files.move(this.fsDir.toPath(), destDir.toPath());
                 res = javax.ws.rs.core.Response.status(HttpStatus.SC_CREATED);
             } else {
+                davDestination.getDestinationRsCmp().getParent().checkAccessContext(ac, BoxPrivilege.BIND);
+                davDestination.getDestinationRsCmp().getParent().checkAccessContext(ac, BoxPrivilege.UNBIND);
                 FileUtils.deleteDirectory(destDir);
                 Files.move(this.fsDir.toPath(), destDir.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 res = javax.ws.rs.core.Response.status(HttpStatus.SC_NO_CONTENT);

--- a/src/main/java/io/personium/core/model/jaxb/Ace.java
+++ b/src/main/java/io/personium/core/model/jaxb/Ace.java
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.XmlType;
  * D: JAXB object corresponding to ace tag.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(namespace = "DAV:", name = "ace", propOrder = {"principal", "grant" })
+@XmlType(namespace = "DAV:", name = "ace", propOrder = {"principal", "grant", "inherited"})
 public final class Ace {
     /**
      * Principal.
@@ -40,6 +40,11 @@ public final class Ace {
      */
     @XmlElement(namespace = "DAV:", name = "grant")
     Grant grant;
+    /**
+     * Grant.
+     */
+    @XmlElement(namespace = "DAV:", name = "inherited")
+    Inherited inherited;
 
     /**
      * @return Principal/href
@@ -86,4 +91,29 @@ public final class Ace {
         return ret;
     }
 
+    /**
+     * get inherited href.
+     * @return inherited href
+     */
+    public String getInheritedHref() {
+        if (this.inherited == null) {
+            return null;
+        }
+        return this.inherited.href;
+    }
+
+    /**
+     * set inherited href.
+     * @param href href
+     */
+    public void setInheritedHref(String href) {
+        if (href != null) {
+            if (this.inherited == null) {
+                this.inherited = new Inherited();
+            }
+            this.inherited.setHref(href);
+        } else {
+            this.inherited = null;
+        }
+    }
 }

--- a/src/main/java/io/personium/core/model/jaxb/Inherited.java
+++ b/src/main/java/io/personium/core/model/jaxb/Inherited.java
@@ -1,0 +1,43 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.model.jaxb;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * D: JAXB object corresponding to inherited tag.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(namespace = "DAV:", name = "inherited")
+public final class Inherited {
+    /**
+     * D: href tag.
+     */
+    @XmlElement(namespace = "DAV:", name = "href")
+    String href;
+
+    /**
+     * set href.
+     * @param href href
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+}

--- a/src/main/java/io/personium/core/rs/box/DavCollectionResource.java
+++ b/src/main/java/io/personium/core/rs/box/DavCollectionResource.java
@@ -88,8 +88,7 @@ public class DavCollectionResource {
     @PROPPATCH
     public Response proppatch(final Reader requestBodyXml) {
         //Access control
-        this.davRsCmp.checkAccessContext(
-                this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
+        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
         Response response = this.davRsCmp.doProppatch(requestBodyXml);
 
         // post event to EventBus
@@ -128,7 +127,7 @@ public class DavCollectionResource {
         boolean recursive = Boolean.valueOf(recursiveHeader);
         // Check acl.(Parent acl check)
         // Since DavCollectionResource always has a parent, result of this.davRsCmp.getParent() will never be null.
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
 
         if (!recursive && !this.davRsCmp.getDavCmp().isEmpty()) {
             throw PersoniumCoreException.Dav.HAS_CHILDREN;
@@ -208,7 +207,7 @@ public class DavCollectionResource {
     @MKCOL
     public Response mkcol() {
         //Access control
-        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.BIND);
 
         throw PersoniumCoreException.Dav.METHOD_NOT_ALLOWED;
     }
@@ -274,7 +273,7 @@ public class DavCollectionResource {
             @Context HttpHeaders headers) {
         //Access control to move source (check parent's authority)
         //Since DavCollectionResource always has a parent (the top is a Box), the result of this.davRsCmp.getParent () will never be null
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
         return new DavMoveResource(this.davRsCmp.getParent(), this.davRsCmp.getDavCmp(), headers).doMove();
     }
 }

--- a/src/main/java/io/personium/core/rs/box/DavFileResource.java
+++ b/src/main/java/io/personium/core/rs/box/DavFileResource.java
@@ -75,7 +75,7 @@ public class DavFileResource {
             @HeaderParam(HttpHeaders.IF_MATCH) final String ifMatch,
             final InputStream inputStream) {
         // Access Control
-        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_CONTENT);
 
         ResponseBuilder rb = this.davRsCmp.getDavCmp().putForUpdate(contentType, inputStream, ifMatch);
         Response res = rb.build();
@@ -141,7 +141,7 @@ public class DavFileResource {
     public Response delete(@HeaderParam(HttpHeaders.IF_MATCH) final String ifMatch) {
         // Access Control
         //The result of this.davRsCmp.getParent () is never null since DavFileResource always has a parent (the top is Box)
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
 
         ResponseBuilder rb = this.davRsCmp.getDavCmp().delete(ifMatch, false);
         Response res = rb.build();
@@ -172,8 +172,7 @@ public class DavFileResource {
     @PROPPATCH
     public Response proppatch(final Reader requestBodyXml) {
         // Access Control
-        this.davRsCmp.checkAccessContext(
-                this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
+        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
         Response response = this.davRsCmp.doProppatch(requestBodyXml);
 
         // post event to EventBus
@@ -271,7 +270,8 @@ public class DavFileResource {
             @Context HttpHeaders headers) {
         // Access Control against the move source
         //The result of this.davRsCmp.getParent () is never null since DavFileResource always has a parent (the top is Box)
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
+
         return new DavMoveResource(this.davRsCmp.getParent(), this.davRsCmp.getDavCmp(), headers).doMove();
     }
 

--- a/src/main/java/io/personium/core/rs/box/NullResource.java
+++ b/src/main/java/io/personium/core/rs/box/NullResource.java
@@ -112,7 +112,9 @@ public class NullResource {
             final InputStream inputStream) {
 
         //Access control
-        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        if (!this.isParentNull) {
+            this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.BIND);
+        }
 
         //If there is no intermediate path 409 error
         /*
@@ -188,7 +190,9 @@ public class NullResource {
             final InputStream inputStream) {
 
         //Access control
-        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        if (!this.isParentNull) {
+            this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.BIND);
+        }
 
         //If there is no intermediate path 409 error
         /*
@@ -279,7 +283,9 @@ public class NullResource {
     @DELETE
     public final Response delete() {
         //Access control
-        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        if (!this.isParentNull) {
+            this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
+        }
 
         throw PersoniumCoreException.Dav.RESOURCE_NOT_FOUND.params(this.davRsCmp.getUrl());
     }
@@ -351,7 +357,9 @@ public class NullResource {
     @MOVE
     public final Response move() {
         //Access control
-        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        if (!this.isParentNull) {
+            this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
+        }
 
         throw PersoniumCoreException.Dav.RESOURCE_NOT_FOUND.params(this.davRsCmp.getUrl());
     }

--- a/src/main/java/io/personium/core/rs/box/ODataSvcCollectionResource.java
+++ b/src/main/java/io/personium/core/rs/box/ODataSvcCollectionResource.java
@@ -116,8 +116,7 @@ public final class ODataSvcCollectionResource extends ODataResource {
     @PROPPATCH
     public Response proppatch(final Reader requestBodyXml) {
         //Access control
-        this.checkAccessContext(
-                this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
+        this.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
 
         Response response = this.davRsCmp.doProppatch(requestBodyXml);
 
@@ -186,7 +185,7 @@ public final class ODataSvcCollectionResource extends ODataResource {
         boolean recursive = Boolean.valueOf(recursiveHeader);
         // Check acl.
         // Since ODataSvcCollectionResource always has a parent, result of this.davRsCmp.getParent() will never be null.
-        this.davRsCmp.getParent().checkAccessContext(this.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.getAccessContext(), BoxPrivilege.UNBIND);
 
         // If OData schema/data already exists, an error
         if (!recursive && !this.davRsCmp.getDavCmp().isEmpty()) {
@@ -240,7 +239,7 @@ public final class ODataSvcCollectionResource extends ODataResource {
     public Response move(
             @Context HttpHeaders headers) {
         //Access control to move source (check parent's authority)
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
         return new DavMoveResource(this.davRsCmp.getParent(), this.davRsCmp.getDavCmp(), headers).doMove();
     }
 

--- a/src/main/java/io/personium/core/rs/box/PersoniumEngineSourceNullResource.java
+++ b/src/main/java/io/personium/core/rs/box/PersoniumEngineSourceNullResource.java
@@ -57,7 +57,7 @@ public class PersoniumEngineSourceNullResource extends NullResource {
             @HeaderParam("Transfer-Encoding") final String transferEncoding,
             final InputStream inputStream) {
         //Access control
-        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.BIND);
         throw PersoniumCoreException.Dav.METHOD_NOT_ALLOWED;
     }
 

--- a/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
+++ b/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
@@ -157,7 +157,7 @@ public class PersoniumEngineSvcCollectionResource {
         boolean recursive = Boolean.valueOf(recursiveHeader);
         // Check acl.(Parent acl check)
         // Since DavCollectionResource always has a parent, result of this.davRsCmp.getParent() will never be null.
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
 
         if (!recursive && !this.davRsCmp.getDavCmp().isEmpty()) {
             throw PersoniumCoreException.Dav.HAS_CHILDREN;
@@ -190,8 +190,7 @@ public class PersoniumEngineSvcCollectionResource {
     @PROPPATCH
     public Response proppatch(final Reader requestBodyXml) {
         //Access control
-        this.davRsCmp.checkAccessContext(
-                this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
+        this.davRsCmp.checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE_PROPERTIES);
         Response response = this.davRsCmp.doProppatch(requestBodyXml);
 
         // post event to EventBus
@@ -569,7 +568,7 @@ public class PersoniumEngineSvcCollectionResource {
     public Response move(
             @Context HttpHeaders headers) {
         //Access control to move source (check parent's authority)
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
         return new DavMoveResource(this.davRsCmp.getParent(), this.davRsCmp.getDavCmp(), headers).doMove();
     }
 }

--- a/src/main/java/io/personium/core/rs/box/StreamCollectionResource.java
+++ b/src/main/java/io/personium/core/rs/box/StreamCollectionResource.java
@@ -119,7 +119,7 @@ public class StreamCollectionResource {
         boolean recursive = Boolean.valueOf(recursiveHeader);
         // Check acl.(Parent acl check)
         // Since DavCollectionResource always has a parent, result of this.davRsCmp.getParent() will never be null.
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
 
         if (!recursive && !this.davRsCmp.getDavCmp().isEmpty()) {
             throw PersoniumCoreException.Dav.HAS_CHILDREN;
@@ -211,7 +211,7 @@ public class StreamCollectionResource {
     public Response move(
             @Context HttpHeaders headers) {
         //Access control to move source (check parent's authority)
-        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.WRITE);
+        this.davRsCmp.getParent().checkAccessContext(this.davRsCmp.getAccessContext(), BoxPrivilege.UNBIND);
         return new DavMoveResource(this.davRsCmp.getParent(), this.davRsCmp.getDavCmp(), headers).doMove();
     }
 

--- a/src/test/java/io/personium/test/jersey/bar/BarInstallTest.java
+++ b/src/test/java/io/personium/test/jersey/bar/BarInstallTest.java
@@ -515,7 +515,7 @@ public class BarInstallTest extends PersoniumTest {
             assertEquals(expected, location);
 
             BarInstallTestUtils.assertBarInstallStatus(location, SCHEMA_URL, ProgressInfo.STATUS.COMPLETED);
-            checkRegistData();
+            checkRegistData(); // TODO ★
         } finally {
             deleteAllData(reqCell, reqPath, user, testCell, odataColName);
         }
@@ -741,7 +741,7 @@ public class BarInstallTest extends PersoniumTest {
                 HttpStatus.SC_MULTI_STATUS);
         Element root = res.bodyAsXml().getDocumentElement();
         // DavCollectionのACLチェック
-        checkAcl(root, rolList, roleName, boxUrl + "/" + colName);
+        checkAcl(root, rolList, rolList, roleName, boxUrl + "/" + colName);
 
         // DavCollection
         DavResourceUtils.getWebDavFile(Setup.TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, "box/dav-get.txt",
@@ -752,7 +752,7 @@ public class BarInstallTest extends PersoniumTest {
                 HttpStatus.SC_MULTI_STATUS);
         root = res.bodyAsXml().getDocumentElement();
         // DavCollectionのACLチェック
-        checkAcl(root, rolList, roleName, boxUrl + "/webdavcol1");
+        checkAcl(root, rolList, rolList, roleName, boxUrl + "/webdavcol1");
         // DavCollectionのAuthorチェック
         String author = root.getElementsByTagNameNS(nameSpace, "Author").item(0).getFirstChild().getNodeValue();
         assertEquals("Test User2", author);
@@ -774,18 +774,27 @@ public class BarInstallTest extends PersoniumTest {
                 token, HttpStatus.SC_MULTI_STATUS, INSTALL_TARGET);
         root = res.bodyAsXml().getDocumentElement();
         // BOXのACLチェック
-        checkAcl(root, rolList, roleName, boxUrl);
+        checkAcl(root, rolList, null, roleName, boxUrl);
         // Box Authorのチェック
         author = root.getElementsByTagNameNS(nameSpace, "Author").item(0).getFirstChild().getNodeValue();
         assertEquals("Test User1", author);
     }
 
     // BOX ACLのチェック
-    private void checkAcl(Element root, List<String> rolList, String roleName, String resourceUrl) {
+    private void checkAcl(Element root, List<String> rolList, List<String> installBoxRolList, String roleName,
+            String resourceUrl) {
         List<Map<String, List<String>>> list = new ArrayList<Map<String, List<String>>>();
         Map<String, List<String>> map = new HashMap<String, List<String>>();
-        list.add(map);
         map.put(roleName, rolList);
+        list.add(map);
+
+        // installBox acl
+        if (installBoxRolList != null) {
+            map = new HashMap<String, List<String>>();
+            map.put("role1", installBoxRolList);
+            list.add(map);
+        }
+
         TestMethodUtils.aclResponseTest(root, resourceUrl, list, 1,
                 UrlUtils.roleResource(Setup.TEST_CELL1, INSTALL_TARGET, ""), null);
     }

--- a/src/test/java/io/personium/test/jersey/bar/BarInstallTest.java
+++ b/src/test/java/io/personium/test/jersey/bar/BarInstallTest.java
@@ -515,7 +515,7 @@ public class BarInstallTest extends PersoniumTest {
             assertEquals(expected, location);
 
             BarInstallTestUtils.assertBarInstallStatus(location, SCHEMA_URL, ProgressInfo.STATUS.COMPLETED);
-            checkRegistData(); // TODO ★
+            checkRegistData();
         } finally {
             deleteAllData(reqCell, reqPath, user, testCell, odataColName);
         }

--- a/src/test/java/io/personium/test/jersey/box/acl/jaxb/Privilege.java
+++ b/src/test/java/io/personium/test/jersey/box/acl/jaxb/Privilege.java
@@ -38,6 +38,7 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="alter-schema" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="read-properties" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="write-properties" type="{http://www.w3.org/2001/XMLSchema}string"/>
+ *         &lt;element name="write-content" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="read-acl" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="write-acl" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="bind" type="{http://www.w3.org/2001/XMLSchema}string"/>
@@ -56,6 +57,7 @@ import javax.xml.bind.annotation.XmlType;
         "alterSchema",
         "readProperties",
         "writeProperties",
+        "writeContent",
         "readAcl",
         "writeAcl",
         "bind",
@@ -74,6 +76,8 @@ public class Privilege {
     String readProperties;
     @XmlElement(name = "write-properties")
     String writeProperties;
+    @XmlElement(name = "write-content")
+    String writeContent;
     @XmlElement(name = "read-acl")
     String readAcl;
     @XmlElement(name = "write-acl")
@@ -171,6 +175,24 @@ public class Privilege {
      */
     public void setWriteProperties(String value) {
         this.writeProperties = value;
+    }
+
+    /**
+     * Gets the value of the writeContent property.
+     * @return
+     *         possible object is {@link String }
+     */
+    public String getWriteContent() {
+        return writeContent;
+    }
+
+    /**
+     * Sets the value of the writeContent property.
+     * @param value
+     *        allowed object is {@link String }
+     */
+    public void setWriteContent(String value) {
+        this.writeContent = value;
     }
 
     /**

--- a/src/test/java/io/personium/test/jersey/box/dav/col/MoveODataCollectionAclTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/MoveODataCollectionAclTest.java
@@ -69,12 +69,16 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
     private static final String MASTER_TOKEN = AbstractCase.MASTER_TOKEN_NAME;
 
     private static final String ACCOUNT_READ = "read-account";
+    private static final String ACCOUNT_BIND = "bind-account";
+    private static final String ACCOUNT_UNBIND = "unbind-account";
     private static final String ACCOUNT_WRITE = "write-account";
     private static final String ACCOUNT_NO_PRIVILEGE = "no-privilege-account";
     private static final String ACCOUNT_ALL_PRIVILEGE = "all-account";
     private static final String ACCOUNT_COMB_PRIVILEGE = "comb-account";
 
     private static final String ROLE_READ = "role-read";
+    private static final String ROLE_BIND = "role-bind";
+    private static final String ROLE_UNBIND = "role-unbind";
     private static final String ROLE_WRITE = "role-write";
     private static final String ROLE_NO_PRIVILEGE = "role-no-privilege";
     private static final String ROLE_ALL_PRIVILEGE = "role-all-privilege";
@@ -175,6 +179,53 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
         TResponse res = DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_FORBIDDEN);
         PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
         ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+    }
+
+    /**
+     * If you move an OData collection with an account that has the move source parent with bind privileges, you get 403 error.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_source_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/%s", BOX_NAME, SRC_COL_NAME, COL_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, COL_NAME);
+        String srcColPath = SRC_COL_NAME + "/" + COL_NAME;
+
+        // Advance preparation
+        setDefaultAcl(SRC_COL_NAME);
+        setPrincipalAllAcl(DST_COL_NAME);
+        DavResourceUtils.createODataCollection(
+                MASTER_TOKEN, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, srcColPath);
+
+        // bind authority
+        token = getToken(ACCOUNT_BIND);
+        TResponse res = DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_FORBIDDEN);
+        PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
+        ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+    }
+
+    /**
+     * If the parent of the move source moves the OData collection with an account with unbind privileges, it will be 201.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_source_has_unbind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/%s", BOX_NAME, SRC_COL_NAME, COL_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, COL_NAME);
+        String srcColPath = SRC_COL_NAME + "/" + COL_NAME;
+
+        // Advance preparation
+        setDefaultAcl(SRC_COL_NAME);
+        setPrincipalAllAcl(DST_COL_NAME);
+
+        DavResourceUtils.createODataCollection(
+                MASTER_TOKEN, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, srcColPath);
+
+        // unbind authority
+        token = getToken(ACCOUNT_UNBIND);
+        DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_CREATED);
     }
 
     /**
@@ -407,7 +458,7 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
     }
 
     /**
-     * 移動元の親にread権限を持つ_かつ_移動対象にread権限を持つアカウントでODataコレクションのMOVEをした場合403となること.
+     * 移動元の親にwrite権限を持つ_かつ_移動対象にread権限を持つアカウントでODataコレクションのMOVEをした場合403となること.
      * @throws JAXBException ACLのパース失敗
      */
     @Test
@@ -426,6 +477,55 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
                 MASTER_TOKEN, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, srcColPath);
 
         // 親にwrite権限+移動先の親にread権限→403
+        token = getToken(ACCOUNT_WRITE);
+        TResponse res = DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_FORBIDDEN);
+        PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
+        ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+    }
+
+
+    /**
+     * If you MOVE OData collection with an account that has write permission for the parent of the move source and _ and _ move object for the move target, it will be 201.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_destination_has_bind_authority()
+            throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/%s", BOX_NAME, SRC_COL_NAME, COL_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, COL_NAME);
+        String srcColPath = SRC_COL_NAME + "/" + COL_NAME;
+
+        // Advance preparation
+        setDefaultAcl(SRC_COL_NAME);
+        setAcl(DST_COL_NAME, ROLE_WRITE, "bind");
+
+        DavResourceUtils.createODataCollection(
+                MASTER_TOKEN, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, srcColPath);
+
+        token = getToken(ACCOUNT_WRITE);
+        DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_CREATED);
+    }
+
+    /**
+     * If you move OData collection with an account that has write permission for the parent of the move source and _ and _ for the move object and has unbind permission for the move target, the result is 403.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_destination_has_unbind_authority()
+            throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/%s", BOX_NAME, SRC_COL_NAME, COL_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, COL_NAME);
+        String srcColPath = SRC_COL_NAME + "/" + COL_NAME;
+
+        // Advance preparation
+        setDefaultAcl(SRC_COL_NAME);
+        setAcl(DST_COL_NAME, ROLE_WRITE, "unbind");
+
+        DavResourceUtils.createODataCollection(
+                MASTER_TOKEN, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, srcColPath);
+
         token = getToken(ACCOUNT_WRITE);
         TResponse res = DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_FORBIDDEN);
         PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
@@ -451,7 +551,7 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
         DavResourceUtils.createODataCollection(
                 MASTER_TOKEN, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, srcColPath);
 
-        // 親にwrite権限+移動先の親にread権限→403
+        // 親にwrite権限+移動先の親にwrite権限→201
         token = getToken(ACCOUNT_WRITE);
         DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_CREATED);
     }
@@ -531,6 +631,8 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
 
         // Role作成
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_READ, HttpStatus.SC_CREATED);
+        RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_BIND, HttpStatus.SC_CREATED);
+        RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_UNBIND, HttpStatus.SC_CREATED);
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_WRITE, HttpStatus.SC_CREATED);
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_NO_PRIVILEGE, HttpStatus.SC_CREATED);
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_ALL_PRIVILEGE, HttpStatus.SC_CREATED);
@@ -538,12 +640,18 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
 
         // Account作成
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_READ, PASSWORD, HttpStatus.SC_CREATED);
+        AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_BIND, PASSWORD, HttpStatus.SC_CREATED);
+        AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_UNBIND, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_WRITE, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_NO_PRIVILEGE, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_ALL_PRIVILEGE, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_COMB_PRIVILEGE, PASSWORD, HttpStatus.SC_CREATED);
         LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_READ, null,
                 Role.EDM_TYPE_NAME, ROLE_READ, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
+        LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_BIND, null,
+                Role.EDM_TYPE_NAME, ROLE_BIND, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
+        LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_UNBIND, null,
+                Role.EDM_TYPE_NAME, ROLE_UNBIND, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
         LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_WRITE, null,
                 Role.EDM_TYPE_NAME, ROLE_WRITE, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
         LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_NO_PRIVILEGE, null,
@@ -560,23 +668,12 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
      * @throws JAXBException ACLのパースに失敗
      */
     private void setDefaultAcl(String collection) throws JAXBException {
-        setDefaultAcl(collection, ROLE_READ, ROLE_WRITE, ROLE_ALL_PRIVILEGE);
-    }
-
-    /**
-     * 指定されたコレクションに対し、Role毎に対応するPrivilegeを設定.
-     * @param collection コレクション名
-     * @param roleRead read権限を設定するRole名
-     * @param roleWrite writed権限を設定するRole名
-     * @param roleAll all権限を設定するRole名
-     * @throws JAXBException ACLのパースに失敗
-     */
-    private void setDefaultAcl(String collection, String roleRead, String roleWrite, String roleAll)
-            throws JAXBException {
         Acl acl = new Acl();
-        acl.getAce().add(DavResourceUtils.createAce(false, roleRead, "read"));
-        acl.getAce().add(DavResourceUtils.createAce(false, roleWrite, "write"));
-        acl.getAce().add(DavResourceUtils.createAce(false, roleAll, "all"));
+        acl.getAce().add(DavResourceUtils.createAce(false, ROLE_READ, "read"));
+        acl.getAce().add(DavResourceUtils.createAce(false, ROLE_BIND, "bind"));
+        acl.getAce().add(DavResourceUtils.createAce(false, ROLE_UNBIND, "unbind"));
+        acl.getAce().add(DavResourceUtils.createAce(false, ROLE_WRITE, "write"));
+        acl.getAce().add(DavResourceUtils.createAce(false, ROLE_ALL_PRIVILEGE, "all"));
         List<String> privileges = new ArrayList<String>();
         privileges.add("read");
         privileges.add("write");

--- a/src/test/java/io/personium/test/jersey/box/dav/col/ODataCollectionAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/ODataCollectionAccessControlTest.java
@@ -152,6 +152,25 @@ public class ODataCollectionAccessControlTest extends PersoniumTest {
     }
 
     /**
+     * Delete the collection with an account that has _ and _ the target collection with unbind permission on the parent collection, and become 204.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void DELETE_parent_has_unbind_authority_and_current_has_not_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_COL_NAME);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "unbind");
+
+        // get token.
+        token = getToken(ACCOUNT);
+
+        // execute
+        DavResourceUtils.deleteCollection(CELL_NAME, BOX_NAME, path, token, HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
      * 親コレクションにwrite権限がある_かつ_対象コレクションにwrite権限があるアカウントでコレクションのDELETEを行い204となること.
      * @throws JAXBException ACLのパース失敗
      */
@@ -206,6 +225,25 @@ public class ODataCollectionAccessControlTest extends PersoniumTest {
         token = getToken(ACCOUNT);
 
         // リクエスト実行
+        DavResourceUtils.createODataCollection(token, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, path);
+    }
+
+    /**
+     * Make MKCOL of the collection with an account that has bind authority to the parent collection and become 201.
+     * @throws JAXBException Advance preparation
+     */
+    @Test
+    public void MKCOL_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, COL_NAME);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "write");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
         DavResourceUtils.createODataCollection(token, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, path);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/ServiceCollectionAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/ServiceCollectionAccessControlTest.java
@@ -152,6 +152,25 @@ public class ServiceCollectionAccessControlTest extends PersoniumTest {
     }
 
     /**
+     * Delete the collection with an account that has _ and _ the target collection with unbind permission on the parent collection, and become 204.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void DELETE_parent_has_unbind_authority_and_current_has_not_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_COL_NAME);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "unbind");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
+        DavResourceUtils.deleteCollection(CELL_NAME, BOX_NAME, path, token, HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
      * 親コレクションにwrite権限がある_かつ_対象コレクションにwrite権限があるアカウントでコレクションのDELETEを行い204となること.
      * @throws JAXBException ACLのパース失敗
      */
@@ -206,6 +225,25 @@ public class ServiceCollectionAccessControlTest extends PersoniumTest {
         token = getToken(ACCOUNT);
 
         // リクエスト実行
+        DavResourceUtils.createODataCollection(token, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, path);
+    }
+
+    /**
+     * Make MKCOL of the collection with an account that has bind authority to the parent collection and become 201.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MKCOL_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, COL_NAME);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "bind");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
         DavResourceUtils.createODataCollection(token, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, path);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/WebDAVCollectionAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/WebDAVCollectionAccessControlTest.java
@@ -166,6 +166,25 @@ public class WebDAVCollectionAccessControlTest extends PersoniumTest {
     }
 
     /**
+     * Delete the collection with an account that has _ and _ the target collection with unbind permission on the parent collection, and become 204.
+     * @throws JAXBException Advance preparation
+     */
+    @Test
+    public void DELETE_parent_has_unbind_authority_and_current_has_not_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_COL_NAME);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "unbind");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
+        DavResourceUtils.deleteCollection(CELL_NAME, BOX_NAME, path, token, HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
      * 親コレクションにwrite権限がある_かつ_対象コレクションにwrite権限があるアカウントでコレクションのDELETEを行い204となること.
      * @throws JAXBException ACLのパース失敗
      */
@@ -220,6 +239,25 @@ public class WebDAVCollectionAccessControlTest extends PersoniumTest {
         token = getToken(ACCOUNT);
 
         // リクエスト実行
+        DavResourceUtils.createWebDavCollection(token, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, path);
+    }
+
+    /**
+     * Make MKCOL of the collection with an account that has bind authority to the parent collection and become 201.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MKCOL_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, COL_NAME);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "bind");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
         DavResourceUtils.createWebDavCollection(token, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME, path);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/file/FileAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/FileAccessControlTest.java
@@ -214,6 +214,26 @@ public class FileAccessControlTest extends PersoniumTest {
     }
 
     /**
+     * Make the file 201 with an account that has bind authority to the parent collection.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void PUT_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_FILE_NAME + "new");
+
+        // ACL設定
+        setAcl(PARENT_COL_NAME, ROLE, "bind");
+
+        // アクセストークン取得
+        token = getToken(ACCOUNT);
+
+        // リクエスト実行
+        DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
+                MediaType.TEXT_PLAIN, HttpStatus.SC_CREATED);
+    }
+
+    /**
      * 親コレクションに権限がない_かつ_対象ファイルに権限がないアカウントでファイルの更新を行い403になること.
      * @throws JAXBException ACLのパース失敗
      */
@@ -233,6 +253,48 @@ public class FileAccessControlTest extends PersoniumTest {
     }
 
     /**
+     * Update the file with an account that has bind permission for the target file and become 403.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void PUT_update_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_FILE_NAME);
+
+        // set ACL
+        setAcl(path, ROLE, "bind");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
+        TResponse res = DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
+                MediaType.TEXT_PLAIN, HttpStatus.SC_FORBIDDEN);
+        PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
+        ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+    }
+
+    /**
+     * The file can be updated with an account that has write-content permission for the target file.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void PUT_update_has_writeContent_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_FILE_NAME);
+
+        // set ACL
+        setAcl(path, ROLE, "write-content");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
+        DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
+                MediaType.TEXT_PLAIN, HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
      * 親コレクションに権限がない_かつ_対象ファイルにwrite権限があるアカウントでファイルの更新ができること.
      * @throws JAXBException ACLのパース失敗
      */
@@ -248,6 +310,26 @@ public class FileAccessControlTest extends PersoniumTest {
         token = getToken(ACCOUNT);
 
         // リクエスト実行
+        DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
+                MediaType.TEXT_PLAIN, HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
+     * Can update files with an account that has write-content permission in the parent collection.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void PUT_update_parent_has_writeContent_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_FILE_NAME);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "write-content");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
         DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
                 MediaType.TEXT_PLAIN, HttpStatus.SC_NO_CONTENT);
     }

--- a/src/test/java/io/personium/test/jersey/box/dav/file/MoveServiceSourceAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/MoveServiceSourceAccessControlTest.java
@@ -71,12 +71,16 @@ public class MoveServiceSourceAccessControlTest extends PersoniumTest {
     private static final String MASTER_TOKEN = AbstractCase.MASTER_TOKEN_NAME;
 
     private static final String ACCOUNT_READ = "read-account";
+    private static final String ACCOUNT_BIND = "bind-account";
+    private static final String ACCOUNT_UNBIND = "unbind-account";
     private static final String ACCOUNT_WRITE = "write-account";
     private static final String ACCOUNT_NO_PRIVILEGE = "no-privilege-account";
     private static final String ACCOUNT_ALL_PRIVILEGE = "all-account";
     private static final String ACCOUNT_COMB_PRIVILEGE = "comb-account";
 
     private static final String ROLE_READ = "role-read";
+    private static final String ROLE_BIND = "role-bind";
+    private static final String ROLE_UNBIND = "role-unbind";
     private static final String ROLE_WRITE = "role-write";
     private static final String ROLE_NO_PRIVILEGE = "role-no-privilege";
     private static final String ROLE_ALL_PRIVILEGE = "role-all-privilege";
@@ -188,6 +192,63 @@ public class MoveServiceSourceAccessControlTest extends PersoniumTest {
 
         } finally {
             DavResourceUtils.deleteWebDavFile(CELL_NAME, MASTER_TOKEN, BOX_NAME, SRC_COL_NAME + "/__src/" + FILE_NAME);
+        }
+    }
+
+    /**
+     * If you move ServiceSource with an account that has bind permission to the move source collection, 403 error occurs.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_source_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/__src/%s", BOX_NAME, SRC_COL_NAME, FILE_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, "__src", FILE_NAME);
+
+        try {
+            // Advance preparation
+            setDefaultAcl(SRC_COL_NAME);
+            setPrincipalAllAcl(DST_COL_NAME);
+
+            DavResourceUtils.createWebDavFile(MASTER_TOKEN, CELL_NAME, path, FILE_BODY, MediaType.TEXT_PLAIN,
+                    HttpStatus.SC_CREATED);
+
+            // bind authority
+            token = getToken(ACCOUNT_BIND);
+            TResponse res = DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination,
+                    HttpStatus.SC_FORBIDDEN);
+            PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
+            ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+
+        } finally {
+            DavResourceUtils.deleteWebDavFile(CELL_NAME, MASTER_TOKEN, BOX_NAME, SRC_COL_NAME + "/__src/" + FILE_NAME);
+        }
+    }
+
+    /**
+     * If you use MOVE of ServiceSource with an account that has unbind authority to the move source Collection, it will be 201.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_source_has_unbind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/__src/%s", BOX_NAME, SRC_COL_NAME, FILE_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, "__src", FILE_NAME);
+
+        try {
+            // Advance preparation
+            setDefaultAcl(SRC_COL_NAME);
+            setPrincipalAllAcl(DST_COL_NAME);
+
+            DavResourceUtils.createWebDavFile(MASTER_TOKEN, CELL_NAME, path, FILE_BODY, MediaType.TEXT_PLAIN,
+                    HttpStatus.SC_CREATED);
+
+            // unbind authority
+            token = getToken(ACCOUNT_UNBIND);
+            DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_CREATED);
+
+        } finally {
+            DavResourceUtils.deleteWebDavFile(CELL_NAME, MASTER_TOKEN, BOX_NAME, DST_COL_NAME + "/__src/" + FILE_NAME);
         }
     }
 
@@ -322,6 +383,63 @@ public class MoveServiceSourceAccessControlTest extends PersoniumTest {
 
             // read権限→403
             token = getToken(ACCOUNT_READ);
+            TResponse res = DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination,
+                    HttpStatus.SC_FORBIDDEN);
+            PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
+            ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+
+        } finally {
+            DavResourceUtils.deleteWebDavFile(CELL_NAME, MASTER_TOKEN, BOX_NAME, SRC_COL_NAME + "/__src/" + FILE_NAME);
+        }
+    }
+
+    /**
+     * If you use MOVE of ServiceSource with an account that has bind permission for move destination Collection, it will be 201.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_destination_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/__src/%s", BOX_NAME, SRC_COL_NAME, FILE_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, "__src", FILE_NAME);
+
+        try {
+            // Advance preparation
+            setPrincipalAllAcl(SRC_COL_NAME);
+            setDefaultAcl(DST_COL_NAME);
+
+            DavResourceUtils.createWebDavFile(MASTER_TOKEN, CELL_NAME, path, FILE_BODY, MediaType.TEXT_PLAIN,
+                    HttpStatus.SC_CREATED);
+
+            // bind authority
+            token = getToken(ACCOUNT_BIND);
+            DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination, HttpStatus.SC_CREATED);
+
+        } finally {
+            DavResourceUtils.deleteWebDavFile(CELL_NAME, MASTER_TOKEN, BOX_NAME, DST_COL_NAME + "/__src/" + FILE_NAME);
+        }
+    }
+
+    /**
+     * If you move ServiceSource with an account that has unbind permission to the destination Collection, a 403 error occurs.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_destination_has_unbind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s/__src/%s", BOX_NAME, SRC_COL_NAME, FILE_NAME);
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, DST_COL_NAME, "__src", FILE_NAME);
+
+        try {
+            // Advance preparation
+            setPrincipalAllAcl(SRC_COL_NAME);
+            setDefaultAcl(DST_COL_NAME);
+
+            DavResourceUtils.createWebDavFile(MASTER_TOKEN, CELL_NAME, path, FILE_BODY, MediaType.TEXT_PLAIN,
+                    HttpStatus.SC_CREATED);
+
+            // unbind authority
+            token = getToken(ACCOUNT_UNBIND);
             TResponse res = DavResourceUtils.moveWebDav(token, CELL_NAME, path, destination,
                     HttpStatus.SC_FORBIDDEN);
             PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
@@ -612,6 +730,8 @@ public class MoveServiceSourceAccessControlTest extends PersoniumTest {
 
         // Role作成
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_READ, HttpStatus.SC_CREATED);
+        RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_BIND, HttpStatus.SC_CREATED);
+        RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_UNBIND, HttpStatus.SC_CREATED);
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_WRITE, HttpStatus.SC_CREATED);
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_NO_PRIVILEGE, HttpStatus.SC_CREATED);
         RoleUtils.create(CELL_NAME, MASTER_TOKEN, ROLE_ALL_PRIVILEGE, HttpStatus.SC_CREATED);
@@ -619,12 +739,18 @@ public class MoveServiceSourceAccessControlTest extends PersoniumTest {
 
         // Account作成
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_READ, PASSWORD, HttpStatus.SC_CREATED);
+        AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_BIND, PASSWORD, HttpStatus.SC_CREATED);
+        AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_UNBIND, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_WRITE, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_NO_PRIVILEGE, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_ALL_PRIVILEGE, PASSWORD, HttpStatus.SC_CREATED);
         AccountUtils.create(MASTER_TOKEN, CELL_NAME, ACCOUNT_COMB_PRIVILEGE, PASSWORD, HttpStatus.SC_CREATED);
         LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_READ, null,
                 Role.EDM_TYPE_NAME, ROLE_READ, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
+        LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_BIND, null,
+                Role.EDM_TYPE_NAME, ROLE_BIND, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
+        LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_UNBIND, null,
+                Role.EDM_TYPE_NAME, ROLE_UNBIND, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
         LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_WRITE, null,
                 Role.EDM_TYPE_NAME, ROLE_WRITE, null, MASTER_TOKEN, HttpStatus.SC_NO_CONTENT);
         LinksUtils.createLinks(CELL_NAME, Account.EDM_TYPE_NAME, ACCOUNT_NO_PRIVILEGE, null,
@@ -643,6 +769,8 @@ public class MoveServiceSourceAccessControlTest extends PersoniumTest {
     private void setDefaultAcl(String collection) throws JAXBException {
         Acl acl = new Acl();
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_READ, "read"));
+        acl.getAce().add(DavResourceUtils.createAce(false, ROLE_BIND, "bind"));
+        acl.getAce().add(DavResourceUtils.createAce(false, ROLE_UNBIND, "unbind"));
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_WRITE, "write"));
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_ALL_PRIVILEGE, "all"));
         List<String> privileges = new ArrayList<String>();

--- a/src/test/java/io/personium/test/jersey/box/dav/file/ServiceSourceAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/ServiceSourceAccessControlTest.java
@@ -229,9 +229,8 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
         ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
     }
 
-    // TODO ★ファイル更新について、自身と親の権限による可否の組み合わせを再度確認する　ここから
     /**
-     * 親コレクションにwrite権限があるアカウントでファイルの更新を行い403になること.
+     * 親コレクションにwrite権限があるアカウントでファイルの更新を行い201となること.
      * @throws JAXBException ACLのパース失敗
      */
     @Test
@@ -247,9 +246,8 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
 
         // リクエスト実行
         DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
-                MediaType.TEXT_PLAIN, HttpStatus.SC_FORBIDDEN);
+                MediaType.TEXT_PLAIN, HttpStatus.SC_NO_CONTENT);
     }
-    // TODO ★ファイル更新について、自身と親の権限による可否の組み合わせを再度確認する　ここまで
 
     /**
      * 親コレクションに権限がないアカウントでファイルの取得を行い403になること.

--- a/src/test/java/io/personium/test/jersey/box/dav/file/ServiceSourceAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/ServiceSourceAccessControlTest.java
@@ -112,6 +112,26 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
     }
 
     /**
+     * Delete the file with an account that has unbind permission on the parent collection and become 204.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void DELETE_parent_has_unbind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_SOURCE_FILE_PATH);
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "write");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
+        TResponse res = DavResourceUtils.deleteWebDavFile(CELL_NAME, token, BOX_NAME, path);
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
      * 親コレクションにwrite権限があるアカウントでファイルのDELETEを行い204となること.
      * @throws JAXBException ACLのパース失敗
      */
@@ -148,6 +168,26 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
                 MediaType.TEXT_PLAIN, HttpStatus.SC_FORBIDDEN);
         PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
         ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+    }
+
+    /**
+     * Make the file 201 with an account that has bind authority to the parent collection.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void PUT_has_bind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_SOURCE_FILE_PATH + "new");
+
+        // set ACL
+        setAcl(PARENT_COL_NAME, ROLE, "bind");
+
+        // get token
+        token = getToken(ACCOUNT);
+
+        // execute
+        DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
+                MediaType.TEXT_PLAIN, HttpStatus.SC_CREATED);
     }
 
     /**
@@ -189,12 +229,13 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
         ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
     }
 
+    // TODO ★ファイル更新について、自身と親の権限による可否の組み合わせを再度確認する　ここから
     /**
-     * 親コレクションにwrite権限があるアカウントでファイルの更新ができること.
+     * 親コレクションにwrite権限があるアカウントでファイルの更新を行い403になること.
      * @throws JAXBException ACLのパース失敗
      */
     @Test
-    public void 親コレクションにwrite権限があるアカウントでファイルの更新ができること() throws JAXBException {
+    public void 親コレクションにwrite権限があるアカウントでファイルの更新を行い403になること() throws JAXBException {
         String token;
         String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_SOURCE_FILE_PATH);
 
@@ -206,8 +247,9 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
 
         // リクエスト実行
         DavResourceUtils.createWebDavFile(token, CELL_NAME, BOX_NAME + "/" + path, "testFileBody",
-                MediaType.TEXT_PLAIN, HttpStatus.SC_NO_CONTENT);
+                MediaType.TEXT_PLAIN, HttpStatus.SC_FORBIDDEN);
     }
+    // TODO ★ファイル更新について、自身と親の権限による可否の組み合わせを再度確認する　ここまで
 
     /**
      * 親コレクションに権限がないアカウントでファイルの取得を行い403になること.
@@ -270,6 +312,32 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
                 HttpStatus.SC_FORBIDDEN);
         PersoniumCoreException expectedException = PersoniumCoreException.Auth.NECESSARY_PRIVILEGE_LACKING;
         ODataCommon.checkErrorResponseBody(res, expectedException.getCode(), expectedException.getMessage());
+    }
+
+    /**
+     * Can move files with an account that has unbind permission on the parent collection of the move source.
+     * @throws JAXBException ACL parse failure
+     */
+    @Test
+    public void MOVE_source_has_unbind_authority() throws JAXBException {
+        String token;
+        String path = String.format("%s/%s", PARENT_COL_NAME, TARGET_SOURCE_FILE_PATH);
+        String dstColName = "dstColName";
+        String destination = UrlUtils.box(CELL_NAME, BOX_NAME, dstColName, "destFile.js");
+
+        // 移動先コレクション作成
+        DavResourceUtils.createWebDavCollection(MASTER_TOKEN, HttpStatus.SC_CREATED, CELL_NAME, BOX_NAME,
+                dstColName);
+        setAcl(dstColName, ROLE, "write");
+
+        // ACL設定
+        setAcl(PARENT_COL_NAME, ROLE, "unbind");
+
+        // アクセストークン取得
+        token = getToken(ACCOUNT);
+
+        // リクエスト実行
+        DavResourceUtils.moveWebDav(token, CELL_NAME, BOX_NAME + "/" + path, destination, HttpStatus.SC_CREATED);
     }
 
     /**

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthTestCommon.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthTestCommon.java
@@ -536,10 +536,39 @@ public class AuthTestCommon extends PersoniumTest {
         DavResourceUtils.setProppatch(tokens.get(WRITE_PROP), HttpStatus.SC_MULTI_STATUS, path);
         DavResourceUtils.setProppatch(tokens.get(READ_PROP), HttpStatus.SC_FORBIDDEN, path);
 
-        // PUT
+        // PUT (no target exists)
         path = "setdavcol/dav1.txt";
+        DavResourceUtils.deleteWebDavFile("box/dav-delete.txt", TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
+                path, -1, TEST_BOX);
         DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(WRITE), "box/dav-put.txt",
                 fileBody, TEST_BOX, path, HttpStatus.SC_CREATED);
+        DavResourceUtils.deleteWebDavFile("box/dav-delete.txt", TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
+                path, HttpStatus.SC_NO_CONTENT, TEST_BOX);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(NO_PRIVILEGE), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(READ), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(WRITE), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_CREATED);
+        DavResourceUtils.deleteWebDavFile("box/dav-delete.txt", TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
+                path, HttpStatus.SC_NO_CONTENT, TEST_BOX);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(READ_WRITE), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_CREATED);
+        DavResourceUtils.deleteWebDavFile("box/dav-delete.txt", TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
+                path, HttpStatus.SC_NO_CONTENT, TEST_BOX);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(READ_ACL), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(WRITE_ACL), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(WRITE_PROP), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(READ_PROP), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
+        // PUT (target exists)
+        DavResourceUtils.createWebDavFile(TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_CREATED);
+        DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(WRITE), "box/dav-put.txt",
+                fileBody, TEST_BOX, path, HttpStatus.SC_NO_CONTENT);
         DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(NO_PRIVILEGE), "box/dav-put.txt",
                 fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
         DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(READ), "box/dav-put.txt",
@@ -556,11 +585,7 @@ public class AuthTestCommon extends PersoniumTest {
                 fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
         DavResourceUtils.createWebDavFile(TEST_CELL1, tokens.get(READ_PROP), "box/dav-put.txt",
                 fileBody, TEST_BOX, path, HttpStatus.SC_FORBIDDEN);
-        DavResourceUtils.deleteWebDavFile("box/dav-delete.txt", TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
-                path, HttpStatus.SC_NO_CONTENT, TEST_BOX);
         // DELETE
-        DavResourceUtils.createWebDavFile(TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, "box/dav-put.txt",
-                fileBody, TEST_BOX, path, HttpStatus.SC_CREATED);
         ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(NO_PRIVILEGE),
                 HttpStatus.SC_FORBIDDEN, path);
         ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(READ),
@@ -666,18 +691,8 @@ public class AuthTestCommon extends PersoniumTest {
         DavResourceUtils.setProppatch(tokens.get(WRITE_ACL), HttpStatus.SC_FORBIDDEN, path);
         DavResourceUtils.setProppatch(tokens.get(WRITE_PROP), HttpStatus.SC_MULTI_STATUS, path);
         DavResourceUtils.setProppatch(tokens.get(READ_PROP), HttpStatus.SC_FORBIDDEN, path);
-        // DELETE
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(NO_PRIVILEGE), HttpStatus.SC_FORBIDDEN, path);
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(READ), HttpStatus.SC_FORBIDDEN, path);
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(WRITE), HttpStatus.SC_NO_CONTENT, path);
-        createSvcCollection(path);
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(READ_WRITE), HttpStatus.SC_NO_CONTENT, path);
-        createSvcCollection(path);
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(READ_ACL), HttpStatus.SC_FORBIDDEN, path);
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(WRITE_ACL), HttpStatus.SC_FORBIDDEN, path);
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(WRITE_PROP), HttpStatus.SC_FORBIDDEN, path);
-        ResourceUtils.delete(DEL_COL_FILE, TEST_CELL1, tokens.get(READ_PROP), HttpStatus.SC_FORBIDDEN, path);
         // OPTIONS
+        createSvcCollection(path);
         UserDataUtils.options(tokens.get(NO_PRIVILEGE), HttpStatus.SC_FORBIDDEN, "/" + allPath);
         UserDataUtils.options(tokens.get(READ), HttpStatus.SC_OK, "/" + allPath);
         UserDataUtils.options(tokens.get(WRITE), HttpStatus.SC_FORBIDDEN, "/" + allPath);

--- a/src/test/java/io/personium/test/utils/DavResourceUtils.java
+++ b/src/test/java/io/personium/test/utils/DavResourceUtils.java
@@ -807,6 +807,8 @@ public class DavResourceUtils {
             privilege.setReadProperties("");
         } else if ("write-properties".equals(type)) {
             privilege.setWriteProperties("");
+        } else if ("write-content".equals(type)) {
+            privilege.setWriteContent("");
         } else if ("read-acl".equals(type)) {
             privilege.setReadAcl("");
         } else if ("write-acl".equals(type)) {

--- a/src/test/java/io/personium/test/utils/TestMethodUtils.java
+++ b/src/test/java/io/personium/test/utils/TestMethodUtils.java
@@ -17,6 +17,7 @@
 package io.personium.test.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -49,6 +50,21 @@ public class TestMethodUtils {
      */
     public static void aclResponseTest(Element doc, String resorce,
             List<Map<String, List<String>>> list, int responseIndex, String baseUrl, String requireSchamaAuthz) {
+        aclResponseTest(doc, resorce, list, null, responseIndex, baseUrl, requireSchamaAuthz);
+    }
+
+    /**
+     * ACL後のPROPFINDの返却値のチェック関数.
+     * @param doc 解析するXMLオブジェクト
+     * @param resorce aclを設定したリソースパス
+     * @param list 設定したACLのMap
+     * @param inheritedHrefList ace inherit href. If it's null it is check omitted.
+     * @param responseIndex responseタグ要素数
+     * @param baseUrl ACLのbase:xml
+     * @param requireSchamaAuthz チェックするrequireSchamaAuthzのレベル。nullだとチェック省略
+     */
+    public static void aclResponseTest(Element doc, String resorce, List<Map<String, List<String>>> list,
+            List<String> inheritedHrefList, int responseIndex, String baseUrl, String requireSchamaAuthz) {
         NodeList response = doc.getElementsByTagName("response");
         assertEquals(responseIndex, response.getLength());
         Element node = (Element) response.item(0);
@@ -94,6 +110,16 @@ public class TestMethodUtils {
                     for (int grantIndex = 0; grantIndex < grantList.size(); grantIndex++) {
                         // grantの確認
                         assertEquals(grantList.get(grantIndex), ace.getGrantedPrivilegeList().get(grantIndex));
+                    }
+                }
+                if (inheritedHrefList != null) {
+                    // check inherited href.
+                    assertEquals(aceList.size(), inheritedHrefList.size());
+                    String inheritedHref = inheritedHrefList.get(aceIndex);
+                    if (inheritedHref != null) {
+                        assertEquals(inheritedHref, ace.getInheritedHref());
+                    } else {
+                        assertNull(ace.getInheritedHref());
                     }
                 }
             }


### PR DESCRIPTION
Support "bind" and "unbind" privileges
- fix [PUT、MKCOL、DELETE、MOVE] permission check.

Include "inherited" tag information in the response of PROPFIND.
- Get inherited ACEs.
- Include "inherited" tag.