### PR TITLE
 #321,#339 Use secure hash in password authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.personium</groupId>
             <artifactId>personium-lib-es-adapter</artifactId>
-            <version>1_es6.6.1_1-SNAPSHOT</version>
+            <version>1_es6.6.1_2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.personium</groupId>
@@ -160,6 +160,21 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
             <version>2.1.10.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>5.1.4.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.61</version>
+        </dependency>
+        <dependency>
+            <groupId>com.kosprov.jargon2</groupId>
+            <artifactId>jargon2-api</artifactId>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.personium</groupId>
             <artifactId>personium-lib-es-adapter</artifactId>
-            <version>1_es6.6.1_1</version>
+            <version>1_es6.6.1_2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.personium</groupId>
@@ -165,6 +165,16 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>5.1.4.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>javax.websocket</groupId>

--- a/src/main/java/io/personium/core/auth/AuthUtils.java
+++ b/src/main/java/io/personium/core/auth/AuthUtils.java
@@ -16,21 +16,21 @@
  */
 package io.personium.core.auth;
 
-import java.io.UnsupportedEncodingException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.CharEncoding;
 import org.apache.commons.net.util.SubnetUtils;
 
-import io.personium.common.utils.PersoniumCoreUtils;
 import io.personium.core.PersoniumCoreException;
 import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.auth.hash.HashPassword;
+import io.personium.core.auth.hash.SCryptHashPasswordImpl;
+import io.personium.core.auth.hash.Sha256HashPasswordImpl;
 import io.personium.core.model.ctl.Account;
 import io.personium.core.model.ctl.Common;
 import io.personium.core.odata.OEntityWrapper;
@@ -44,7 +44,13 @@ import io.personium.plugin.base.auth.AuthPlugin;
  * Authentication related utilities.
  */
 public final class AuthUtils {
-    private static final String MD_ALGORITHM = "SHA-256";
+
+    /** hash algorithm name array. */
+    public static final String[] HASH_ALGORITHM_NAMES = {
+            Sha256HashPasswordImpl.HASH_ALGORITHM_NAME,
+            SCryptHashPasswordImpl.HASH_ALGORITHM_NAME
+    };
+
     /** Password minimum length.*/
     private static final int MIN_PASSWORD_LENGTH = 1;
     /** Password maximum length.*/
@@ -54,44 +60,74 @@ public final class AuthUtils {
     }
 
     /**
-     * Hash string of password string.
-     * @param passwd raw password string
-     * @return hashed password string
-     */
-    public static String hashPassword(final String passwd) {
-        if (passwd == null) {
-            return null;
-        }
-
-        // DC0 Ruby Code
-        // Digest::SHA256.hexdigest(pw + "Password hash salt value")
-        String str2hash = passwd + PersoniumUnitConfig.getAuthPasswordSalt();
-        try {
-            MessageDigest md = MessageDigest.getInstance(MD_ALGORITHM);
-            byte[] digestBytes = md.digest(str2hash.getBytes(CharEncoding.UTF_8));
-            //Although its data efficiency is better, this implementation is made for compatibility with DC 0.
-            return PersoniumCoreUtils.byteArray2HexString(digestBytes);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
      * Perform hashing of the password.
+     * Returns the value to be set in the hashed parameters.
      * Validate the password before hashing.
      * @param pCredHeader pCredHeader
      * @param entitySetName entitySetName
-     * @return hashing password
+     * @return hashed parameters
      */
-    public static String hashPassword(String pCredHeader, String entitySetName) {
+    public static Map<String, String> hashPassword(String pCredHeader, String entitySetName) {
         if (!Account.EDM_TYPE_NAME.equals(entitySetName)) {
             return null;
         }
+        //
+        if (pCredHeader == null) {
+            return null;
+        }
+
+        // validate password.
         validatePassword(pCredHeader);
-        String hPassStr = AuthUtils.hashPassword(pCredHeader);
-        return hPassStr;
+
+        // create hash password
+        String hashAlgorithmName = PersoniumUnitConfig.getAuthPasswordHashAlgorithm();
+        HashPassword hpi = getHashPasswordInstance(hashAlgorithmName);
+        String hPassStr = hpi.hashPassword(pCredHeader);
+
+        // return hashed parameters
+        Map<String, String> hashedParams = new HashMap<>();
+        hashedParams.put(Account.HASHED_CREDENTIAL, hPassStr);
+        hashedParams.put(Account.HASHED_ALGORITHM, hpi.algorithmName());
+        hashedParams.put(Account.HASHED_ATTRIBUTES, hpi.hashAttrbutes());
+        return hashedParams;
+    }
+
+    /**
+     * check matche password.
+     * @param oew odata entity wrapper
+     * @param rawPasswd raw password string
+     * @return true if matches password.
+     */
+    public static boolean isMatchePassword(OEntityWrapper oew, String rawPasswd) {
+        // In order to cope with the todo time exploiting attack, even if an ID is not found, processing is done uselessly.
+        String hashAlgorithmName = null;
+        if (oew != null) {
+            hashAlgorithmName = (String) oew.get(Account.HASHED_ALGORITHM);
+        }
+        HashPassword hpi = getHashPasswordInstance(hashAlgorithmName);
+        if (hpi == null) {
+            return false;
+        }
+        return hpi.matches(oew, rawPasswd);
+    }
+
+    /**
+     * get hash password instance.
+     * @param hashAlgorithmName hash algorithm name.
+     * @return hash password instance.
+     */
+    public static HashPassword getHashPasswordInstance(String hashAlgorithmName) {
+        if (SCryptHashPasswordImpl.HASH_ALGORITHM_NAME.equals(hashAlgorithmName)) {
+            return new SCryptHashPasswordImpl();
+        }
+        if (Sha256HashPasswordImpl.HASH_ALGORITHM_NAME.equals(hashAlgorithmName)) {
+            return new Sha256HashPasswordImpl();
+        }
+        if (hashAlgorithmName == null || hashAlgorithmName.isEmpty()) {
+            // If the hash algorithm is not set, it is determined as a legacy hash algorithm.
+            return new Sha256HashPasswordImpl();
+        }
+        return null;
     }
 
     /**
@@ -136,7 +172,7 @@ public final class AuthUtils {
      * @return List<String>
      */
     public static List<String> getAccountType(OEntityWrapper oew) {
-        String typeStr =  (String) oew.getProperty(Account.P_TYPE.getName()).getValue();
+        String typeStr = (String) oew.getProperty(Account.P_TYPE.getName()).getValue();
         String[] typeAry = typeStr.split(" ");
         return Arrays.asList(typeAry);
     }
@@ -147,6 +183,9 @@ public final class AuthUtils {
      * @return List<String>
     */
     public static boolean isAccountTypeBasic(OEntityWrapper oew) {
+        if (oew == null) {
+            return false;
+        }
         return getAccountType(oew).contains(Account.TYPE_VALUE_BASIC);
     }
 
@@ -273,7 +312,10 @@ public final class AuthUtils {
      * @return List<String>
      */
     private static List<String> getIPAddressRangeList(OEntityWrapper oew) {
-        String addrStr =  (String) oew.getProperty(Account.P_IP_ADDRESS_RANGE.getName()).getValue();
+        if (oew == null) {
+            return null;
+        }
+        String addrStr = (String) oew.getProperty(Account.P_IP_ADDRESS_RANGE.getName()).getValue();
         if (addrStr == null || addrStr.isEmpty()) {
             return null;
         }
@@ -287,7 +329,10 @@ public final class AuthUtils {
      * @return status
      */
     public static String getStatus(OEntityWrapper oew) {
-        String status =  (String) oew.getProperty(Account.P_STATUS.getName()).getValue();
+        if (oew == null) {
+            return null;
+        }
+        String status = (String) oew.getProperty(Account.P_STATUS.getName()).getValue();
         return status;
     }
 }

--- a/src/main/java/io/personium/core/auth/AuthUtils.java
+++ b/src/main/java/io/personium/core/auth/AuthUtils.java
@@ -103,6 +103,8 @@ public final class AuthUtils {
         String hashAlgorithmName = null;
         if (oew != null) {
             hashAlgorithmName = (String) oew.get(Account.HASH_ALGORITHM);
+        } else {
+            hashAlgorithmName = PersoniumUnitConfig.getAuthPasswordHashAlgorithm();
         }
         HashPassword hpi = getHashPasswordInstance(hashAlgorithmName);
         if (hpi == null) {

--- a/src/main/java/io/personium/core/auth/AuthUtils.java
+++ b/src/main/java/io/personium/core/auth/AuthUtils.java
@@ -82,13 +82,13 @@ public final class AuthUtils {
         // create hash password
         String hashAlgorithmName = PersoniumUnitConfig.getAuthPasswordHashAlgorithm();
         HashPassword hpi = getHashPasswordInstance(hashAlgorithmName);
-        String hPassStr = hpi.hashPassword(pCredHeader);
+        String hPassStr = hpi.createHashPassword(pCredHeader);
 
         // return hashed parameters
         Map<String, String> hashedParams = new HashMap<>();
         hashedParams.put(Account.HASHED_CREDENTIAL, hPassStr);
-        hashedParams.put(Account.HASHED_ALGORITHM, hpi.algorithmName());
-        hashedParams.put(Account.HASHED_ATTRIBUTES, hpi.hashAttrbutes());
+        hashedParams.put(Account.HASH_ALGORITHM, hpi.getAlgorithmName());
+        hashedParams.put(Account.HASH_ATTRIBUTES, hpi.createHashAttrbutes());
         return hashedParams;
     }
 
@@ -102,7 +102,7 @@ public final class AuthUtils {
         // In order to cope with the todo time exploiting attack, even if an ID is not found, processing is done uselessly.
         String hashAlgorithmName = null;
         if (oew != null) {
-            hashAlgorithmName = (String) oew.get(Account.HASHED_ALGORITHM);
+            hashAlgorithmName = (String) oew.get(Account.HASH_ALGORITHM);
         }
         HashPassword hpi = getHashPasswordInstance(hashAlgorithmName);
         if (hpi == null) {

--- a/src/main/java/io/personium/core/auth/hash/HashPassword.java
+++ b/src/main/java/io/personium/core/auth/hash/HashPassword.java
@@ -27,20 +27,20 @@ public interface HashPassword {
      * get algorithm name.
      * @return algorithm name
      */
-    String algorithmName();
+    String getAlgorithmName();
 
     /**
      * Hash string of password string.
      * @param passwd raw password string
      * @return hashed password string
      */
-    String hashPassword(String passwd);
+    String createHashPassword(String passwd);
 
     /**
      * get hash attrbutes.
      * @return hash attrbutes.
      */
-    String hashAttrbutes();
+    String createHashAttrbutes();
 
     /**
      * matches password.

--- a/src/main/java/io/personium/core/auth/hash/HashPassword.java
+++ b/src/main/java/io/personium/core/auth/hash/HashPassword.java
@@ -1,0 +1,52 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.auth.hash;
+
+import io.personium.core.odata.OEntityWrapper;
+
+/**
+ * A utility hash password interface.
+ */
+public interface HashPassword {
+
+    /**
+     * get algorithm name.
+     * @return algorithm name
+     */
+    String algorithmName();
+
+    /**
+     * Hash string of password string.
+     * @param passwd raw password string
+     * @return hashed password string
+     */
+    String hashPassword(String passwd);
+
+    /**
+     * get hash attrbutes.
+     * @return hash attrbutes.
+     */
+    String hashAttrbutes();
+
+    /**
+     * matches password.
+     * @param oew account
+     * @param rawPasswd raw password string
+     * @return true if matches password.
+     */
+    boolean matches(OEntityWrapper oew, String rawPasswd);
+}

--- a/src/main/java/io/personium/core/auth/hash/SCryptHashPasswordImpl.java
+++ b/src/main/java/io/personium/core/auth/hash/SCryptHashPasswordImpl.java
@@ -115,8 +115,7 @@ public class SCryptHashPasswordImpl implements HashPassword {
         if (cred != null && !cred.isEmpty()) {
             return passwordEncoder.matches(rawPasswd, cred);
         } else {
-            // In order to cope with the todo time exploiting attack,
-            // even if an ID is not found, processing is done uselessly.
+            // In order to cope with the todo time exploiting attack, even if an ID is not found, processing is done uselessly.
             if (dummyCred == null) {
                 dummyCred = passwordEncoder.encode("dummyCred");
             }

--- a/src/main/java/io/personium/core/auth/hash/SCryptHashPasswordImpl.java
+++ b/src/main/java/io/personium/core/auth/hash/SCryptHashPasswordImpl.java
@@ -1,0 +1,152 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.auth.hash;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
+
+import io.personium.core.PersoniumCoreException;
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.model.ctl.Account;
+import io.personium.core.odata.OEntityWrapper;
+
+/**
+ * A utility SCrypt hash password.
+ */
+public class SCryptHashPasswordImpl implements HashPassword {
+    /** Logger. */
+    static Logger log = LoggerFactory.getLogger(SCryptHashPasswordImpl.class);
+
+    /** hash algorithm name. */
+    public static final String HASH_ALGORITHM_NAME = "SCrypt";
+    /** hash attribute keyLength. */
+    public static final String HASH_ATTRIBUTE_KEYLENGTH = "keyLength";
+    /** dummy Hashed credential. */
+    private static String dummyCred = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String algorithmName() {
+        return HASH_ALGORITHM_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String hashPassword(String passwd) {
+        if (passwd == null) {
+            return null;
+        }
+
+        int cpuCost = PersoniumUnitConfig.getSCryptCpuCost();
+        int memoryCost = PersoniumUnitConfig.getSCryptMemoryCost();
+        int parallelization = PersoniumUnitConfig.getSCryptParallelization();
+        int keyLength = PersoniumUnitConfig.getSCryptKeyLength();
+        int saltLength = PersoniumUnitConfig.getSCryptSaltLength();
+        PasswordEncoder passwordEncoder = new SCryptPasswordEncoder(
+                cpuCost, memoryCost, parallelization, keyLength, saltLength);
+
+        // password hash.
+        String str2hash = passwordEncoder.encode(passwd);
+        return str2hash;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public String hashAttrbutes() {
+        // Set attributes.
+        JSONObject json = new JSONObject();
+        json.put(HASH_ATTRIBUTE_KEYLENGTH, PersoniumUnitConfig.getSCryptKeyLength());
+        return json.toJSONString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(OEntityWrapper oew, String rawPasswd) {
+
+        // Parameters other than keyLength are required to generate Instanse but are not actually used.
+        // (Obtained from hash at verification)
+        int cpuCost = PersoniumUnitConfig.getSCryptCpuCost();
+        int memoryCost = PersoniumUnitConfig.getSCryptMemoryCost();
+        int parallelization = PersoniumUnitConfig.getSCryptParallelization();
+        int saltLength = PersoniumUnitConfig.getSCryptSaltLength();
+
+        // get hashed credential.
+        String cred = null;
+        if (oew != null && (String) oew.get(Account.HASHED_CREDENTIAL) != null) {
+            cred = (String) oew.get(Account.HASHED_CREDENTIAL);
+        }
+
+        // get key length.
+        Integer keyLength = getKeyLenghtFromOEntityWrapper(oew);
+        if (keyLength == null) {
+            keyLength = PersoniumUnitConfig.getSCryptKeyLength();
+        }
+
+        // matchs
+        PasswordEncoder passwordEncoder = new SCryptPasswordEncoder(
+                cpuCost, memoryCost, parallelization, keyLength, saltLength);
+        if (cred != null && !cred.isEmpty()) {
+            return passwordEncoder.matches(rawPasswd, cred);
+        } else {
+            // In order to cope with the todo time exploiting attack,
+            // even if an ID is not found, processing is done uselessly.
+            if (dummyCred == null) {
+                dummyCred = passwordEncoder.encode("dummyCred");
+            }
+            passwordEncoder.matches(rawPasswd, dummyCred);
+            return false;
+        }
+    }
+
+    /**
+     * get keyLength from OEntityWrapper.
+     * @param oew OEntityWrapper
+     * @return keyLength
+     */
+    private Integer getKeyLenghtFromOEntityWrapper(OEntityWrapper oew) {
+        if (oew == null || oew.get(Account.HASHED_ATTRIBUTES) == null) {
+            return null;
+        }
+
+        Integer keyLength = null;
+        String attributesStr = (String) oew.get(Account.HASHED_ATTRIBUTES);
+        try {
+            JSONParser parser = new JSONParser();
+            JSONObject attributes;
+            attributes = (JSONObject) parser.parse(attributesStr);
+            if (attributes.containsKey(HASH_ATTRIBUTE_KEYLENGTH)) {
+                keyLength = new Integer(attributes.get(HASH_ATTRIBUTE_KEYLENGTH).toString());
+            }
+        } catch (Exception e) {
+            throw PersoniumCoreException.Common.JSON_PARSE_ERROR.params(attributesStr);
+        }
+        return keyLength;
+    }
+}

--- a/src/main/java/io/personium/core/auth/hash/SCryptHashPasswordImpl.java
+++ b/src/main/java/io/personium/core/auth/hash/SCryptHashPasswordImpl.java
@@ -36,7 +36,7 @@ public class SCryptHashPasswordImpl implements HashPassword {
     static Logger log = LoggerFactory.getLogger(SCryptHashPasswordImpl.class);
 
     /** hash algorithm name. */
-    public static final String HASH_ALGORITHM_NAME = "SCrypt";
+    public static final String HASH_ALGORITHM_NAME = "scrypt";
     /** hash attribute keyLength. */
     public static final String HASH_ATTRIBUTE_KEYLENGTH = "keyLength";
     /** dummy Hashed credential. */
@@ -46,7 +46,7 @@ public class SCryptHashPasswordImpl implements HashPassword {
      * {@inheritDoc}
      */
     @Override
-    public String algorithmName() {
+    public String getAlgorithmName() {
         return HASH_ALGORITHM_NAME;
     }
 
@@ -54,7 +54,7 @@ public class SCryptHashPasswordImpl implements HashPassword {
      * {@inheritDoc}
      */
     @Override
-    public String hashPassword(String passwd) {
+    public String createHashPassword(String passwd) {
         if (passwd == null) {
             return null;
         }
@@ -77,7 +77,7 @@ public class SCryptHashPasswordImpl implements HashPassword {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public String hashAttrbutes() {
+    public String createHashAttrbutes() {
         // Set attributes.
         JSONObject json = new JSONObject();
         json.put(HASH_ATTRIBUTE_KEYLENGTH, PersoniumUnitConfig.getSCryptKeyLength());
@@ -130,12 +130,12 @@ public class SCryptHashPasswordImpl implements HashPassword {
      * @return keyLength
      */
     private Integer getKeyLenghtFromOEntityWrapper(OEntityWrapper oew) {
-        if (oew == null || oew.get(Account.HASHED_ATTRIBUTES) == null) {
+        if (oew == null || oew.get(Account.HASH_ATTRIBUTES) == null) {
             return null;
         }
 
         Integer keyLength = null;
-        String attributesStr = (String) oew.get(Account.HASHED_ATTRIBUTES);
+        String attributesStr = (String) oew.get(Account.HASH_ATTRIBUTES);
         try {
             JSONParser parser = new JSONParser();
             JSONObject attributes;

--- a/src/main/java/io/personium/core/auth/hash/Sha256HashPasswordImpl.java
+++ b/src/main/java/io/personium/core/auth/hash/Sha256HashPasswordImpl.java
@@ -80,8 +80,7 @@ public class Sha256HashPasswordImpl implements HashPassword {
      */
     @Override
     public boolean matches(OEntityWrapper oew, String rawPasswd) {
-        // In order to cope with the todo time exploiting attack,
-        // even if an ID is not found, processing is done uselessly.
+        // In order to cope with the todo time exploiting attack, even if an ID is not found, processing is done uselessly.
         String cred = null;
         if (oew != null) {
             cred = (String) oew.get(Account.HASHED_CREDENTIAL);

--- a/src/main/java/io/personium/core/auth/hash/Sha256HashPasswordImpl.java
+++ b/src/main/java/io/personium/core/auth/hash/Sha256HashPasswordImpl.java
@@ -1,0 +1,96 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.auth.hash;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.lang.CharEncoding;
+
+import io.personium.common.utils.PersoniumCoreUtils;
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.model.ctl.Account;
+import io.personium.core.odata.OEntityWrapper;
+
+/**
+ * A utility SHA-256 hash password.
+ */
+public class Sha256HashPasswordImpl implements HashPassword {
+
+    /** hash algorithm name. */
+    public static final String HASH_ALGORITHM_NAME = "SHA-256";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String algorithmName() {
+        return HASH_ALGORITHM_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String hashPassword(String passwd) {
+        if (passwd == null) {
+            return null;
+        }
+
+        // DC0 Ruby Code
+        // Digest::SHA256.hexdigest(pw + "Password hash salt value")
+        String str2hash = passwd + PersoniumUnitConfig.getAuthPasswordSalt();
+        try {
+            MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHM_NAME);
+            byte[] digestBytes = md.digest(str2hash.getBytes(CharEncoding.UTF_8));
+            //Although its data efficiency is better, this implementation is made for compatibility with DC 0.
+            return PersoniumCoreUtils.byteArray2HexString(digestBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String hashAttrbutes() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(OEntityWrapper oew, String rawPasswd) {
+        // In order to cope with the todo time exploiting attack,
+        // even if an ID is not found, processing is done uselessly.
+        String cred = null;
+        if (oew != null) {
+            cred = (String) oew.get(Account.HASHED_CREDENTIAL);
+        }
+        String hCred = this.hashPassword(rawPasswd);
+        if (hCred.equals(cred)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/io/personium/core/auth/hash/Sha256HashPasswordImpl.java
+++ b/src/main/java/io/personium/core/auth/hash/Sha256HashPasswordImpl.java
@@ -33,13 +33,13 @@ import io.personium.core.odata.OEntityWrapper;
 public class Sha256HashPasswordImpl implements HashPassword {
 
     /** hash algorithm name. */
-    public static final String HASH_ALGORITHM_NAME = "SHA-256";
+    public static final String HASH_ALGORITHM_NAME = "sha-256";
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public String algorithmName() {
+    public String getAlgorithmName() {
         return HASH_ALGORITHM_NAME;
     }
 
@@ -47,7 +47,7 @@ public class Sha256HashPasswordImpl implements HashPassword {
      * {@inheritDoc}
      */
     @Override
-    public String hashPassword(String passwd) {
+    public String createHashPassword(String passwd) {
         if (passwd == null) {
             return null;
         }
@@ -71,7 +71,7 @@ public class Sha256HashPasswordImpl implements HashPassword {
      * {@inheritDoc}
      */
     @Override
-    public String hashAttrbutes() {
+    public String createHashAttrbutes() {
         return null;
     }
 
@@ -85,7 +85,7 @@ public class Sha256HashPasswordImpl implements HashPassword {
         if (oew != null) {
             cred = (String) oew.get(Account.HASHED_CREDENTIAL);
         }
-        String hCred = this.hashPassword(rawPasswd);
+        String hCred = this.createHashPassword(rawPasswd);
         if (hCred.equals(cred)) {
             return true;
         }

--- a/src/main/java/io/personium/core/auth/hash/package-info.java
+++ b/src/main/java/io/personium/core/auth/hash/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * classes for hash password.
+ */
+package io.personium.core.auth.hash;

--- a/src/main/java/io/personium/core/model/ctl/Account.java
+++ b/src/main/java/io/personium/core/model/ctl/Account.java
@@ -59,6 +59,13 @@ public class Account {
      */
     public static final String EDM_TYPE_NAME = "Account";
 
+    /** Hashed credential. */
+    public static final String HASHED_CREDENTIAL = "HashedCredential";
+    /** Hashed algorithm. */
+    public static final String HASHED_ALGORITHM = "HashedAlgorithm";
+    /** Hashed arguments. */
+    public static final String HASHED_ATTRIBUTES = "HashedAttributes";
+
     /**
      * NavigationProperty name with ReceivedMessage.
      */
@@ -80,7 +87,7 @@ public class Account {
                  Common.P_FORMAT, P_FORMAT_PATTERN_IP_ADDRESS_RANGE);
      }
 
-     /**
+    /**
      * Create annotation for status.
      * @return EdmAnnotation
      */

--- a/src/main/java/io/personium/core/model/ctl/Account.java
+++ b/src/main/java/io/personium/core/model/ctl/Account.java
@@ -62,9 +62,9 @@ public class Account {
     /** Hashed credential. */
     public static final String HASHED_CREDENTIAL = "HashedCredential";
     /** Hashed algorithm. */
-    public static final String HASHED_ALGORITHM = "HashedAlgorithm";
+    public static final String HASH_ALGORITHM = "HashAlgorithm";
     /** Hashed arguments. */
-    public static final String HASHED_ATTRIBUTES = "HashedAttributes";
+    public static final String HASH_ATTRIBUTES = "HashAttributes";
 
     /**
      * NavigationProperty name with ReceivedMessage.

--- a/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
@@ -502,17 +502,7 @@ public class CellEsImpl implements Cell {
 
     @Override
     public boolean authenticateAccount(final OEntityWrapper oew, final String password) {
-        //In order to cope with the TODO time exploiting attack (name has been forgotten), even if an ID is not found, processing is done uselessly.
-        String cred = null;
-        if (oew != null) {
-            cred = (String) oew.get("HashedCredential");
-        }
-        String hCred = AuthUtils.hashPassword(password);
-        if (hCred.equals(cred)) {
-            return true;
-        }
-
-        return false;
+        return AuthUtils.isMatchePassword(oew, password);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/personium/core/model/impl/es/odata/EsODataProducer.java
+++ b/src/main/java/io/personium/core/model/impl/es/odata/EsODataProducer.java
@@ -2782,10 +2782,10 @@ public abstract class EsODataProducer implements PersoniumODataProducer {
 
         //Update hidden fields information and UnitUser name.
         //However, in case of updating Account, it is necessary not to replace HashedCredential.
-        String hashedCredentialValue = (String) oedhNew.getHiddenFields().get("HashedCredential");
+        String hashedCredentialValue = (String) oedhNew.getHiddenFields().get(Account.HASHED_CREDENTIAL);
         oedhNew.getHiddenFields().putAll(oedhExisting.getHiddenFields());
         if (hashedCredentialValue != null) {
-            oedhNew.getHiddenFields().put("HashedCredential", hashedCredentialValue);
+            oedhNew.getHiddenFields().put(Account.HASHED_CREDENTIAL, hashedCredentialValue);
         }
         oedhNew.resolveUnitUserName(oedhExisting.getHiddenFields());
 

--- a/src/main/java/io/personium/core/model/impl/es/odata/ODataProducerUtils.java
+++ b/src/main/java/io/personium/core/model/impl/es/odata/ODataProducerUtils.java
@@ -226,13 +226,15 @@ public final class ODataProducerUtils {
      */
     public static void createRequestPassword(EntitySetDocHandler oedhNew, String dcCredHeader) {
         //Pre-update processing (obtain Hash string converted password)
-        String hPassStr = AuthUtils.hashPassword(dcCredHeader, oedhNew.getType());
+        Map<String, String> hashed = AuthUtils.hashPassword(dcCredHeader, oedhNew.getType());
         //Overwrite password to be changed to HashedCredential
         Map<String, Object> hiddenFields = oedhNew.getHiddenFields();
         //Put the value of X-Personium-Credential into the key of HashedCredential
         //If there is no designation, return 400 error
-        if (hPassStr != null) {
-            hiddenFields.put("HashedCredential", hPassStr);
+        if (hashed != null) {
+            for (Map.Entry<String, String> hashedEntry : hashed.entrySet()) {
+                hiddenFields.put(hashedEntry.getKey(), hashedEntry.getValue());
+            }
         } else {
             throw PersoniumCoreException.Auth.P_CREDENTIAL_REQUIRED;
         }

--- a/src/main/java/io/personium/core/model/lock/AccountLockManager.java
+++ b/src/main/java/io/personium/core/model/lock/AccountLockManager.java
@@ -92,10 +92,12 @@ public abstract class AccountLockManager extends LockManager {
      * @return failed count
      */
     public static long getFailedCount(final String accountId) {
+        if (accountId == null || accountId.isEmpty()) {
+            return 0;
+        }
         if (accountLockCount == 0 || accountLockTime == 0) {
             return 0;
         }
-
         String key = CATEGORY_ACCOUNT_LOCK + accountId;
         try {
             long failedCount = singleton.doGetAccountLock(key);

--- a/src/main/java/io/personium/core/model/lock/AccountValidAuthnIntervalLockManager.java
+++ b/src/main/java/io/personium/core/model/lock/AccountValidAuthnIntervalLockManager.java
@@ -51,6 +51,9 @@ public abstract class AccountValidAuthnIntervalLockManager extends LockManager {
      * @return TRUE: Lock / FALSE: Unlock
      */
     public static boolean hasLockObject(final String accountId) {
+        if (accountId == null || accountId.isEmpty()) {
+            return false;
+        }
         try {
             String key = CATEGORY_ACCOUNT_VALID_AUTHENTICATION_INTERVAL + accountId;
             //Confirm Lock of target account

--- a/src/main/java/io/personium/core/rs/cell/CellCtlResource.java
+++ b/src/main/java/io/personium/core/rs/cell/CellCtlResource.java
@@ -17,6 +17,7 @@
 package io.personium.core.rs.cell;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.OPTIONS;
@@ -103,9 +104,11 @@ public final class CellCtlResource extends ODataResource {
         String entitySetName = oEntityWrapper.getEntitySet().getName();
         AuthUtils.validateAccountType(oEntityWrapper, entitySetName);
         AuthUtils.validateAccountIPAddressRange(oEntityWrapper, entitySetName);
-        String hPassStr = AuthUtils.hashPassword(pCredHeader, entitySetName);
-        if (hPassStr != null) {
-            oEntityWrapper.put("HashedCredential", hPassStr);
+        Map<String, String> hashed = AuthUtils.hashPassword(pCredHeader, entitySetName);
+        if (hashed != null) {
+            for (Map.Entry<String, String> hashedEntry : hashed.entrySet()) {
+                oEntityWrapper.put(hashedEntry.getKey(), hashedEntry.getValue());
+            }
         }
     }
 
@@ -114,9 +117,11 @@ public final class CellCtlResource extends ODataResource {
         String entitySetName = oEntityWrapper.getEntitySet().getName();
         AuthUtils.validateAccountType(oEntityWrapper, entitySetName);
         AuthUtils.validateAccountIPAddressRange(oEntityWrapper, entitySetName);
-        String hPassStr = AuthUtils.hashPassword(pCredHeader, entitySetName);
-        if (hPassStr != null) {
-            oEntityWrapper.put("HashedCredential", hPassStr);
+        Map<String, String> hashed = AuthUtils.hashPassword(pCredHeader, entitySetName);
+        if (hashed != null) {
+            for (Map.Entry<String, String> hashedEntry : hashed.entrySet()) {
+                oEntityWrapper.put(hashedEntry.getKey(), hashedEntry.getValue());
+            }
         }
     }
 

--- a/src/main/resources/personium-messages.properties
+++ b/src/main/resources/personium-messages.properties
@@ -177,6 +177,7 @@ io.personium.core.msg.PR409-RM-0005=RequestRelation and RequestRelationTarget is
 io.personium.core.msg.PR400-AU-0001=Password format is invalid.
 io.personium.core.msg.PR400-AU-0002=Request parameter is invalid [{0}].
 io.personium.core.msg.PR400-AU-0003=Personium credential required.
+io.personium.core.msg.PR400-AN-0004=Unsupported hash algorithm.
 
 # PR401-AU
 io.personium.core.msg.PR401-AU-0001=Authorization required.

--- a/src/main/resources/personium-unit-config-default.properties
+++ b/src/main/resources/personium-unit-config-default.properties
@@ -103,7 +103,7 @@ io.personium.core.masterToken=
 #io.personium.core.security.secret16=changeme
 #io.personium.core.security.auth.password.salt=changeme
 io.personium.core.security.auth.password.regex=^[a-zA-Z0-9-_!$*=^`{|}~.@]{6,32}$
-io.personium.core.security.auth.password.hashAlgorithm=SCrypt
+io.personium.core.security.auth.password.hashAlgorithm=scrypt
 io.personium.core.security.auth.password.scrypt.cpuCost=16384
 io.personium.core.security.auth.password.scrypt.memoryCost=8
 io.personium.core.security.auth.password.scrypt.parallelization=1

--- a/src/main/resources/personium-unit-config-default.properties
+++ b/src/main/resources/personium-unit-config-default.properties
@@ -47,6 +47,7 @@ io.personium.core.engine.path=personium-engine
 # cell configurations
 #io.personium.core.cell.relayhtmlurl.default=https://demo.personium.io/app-cc-home/__/index.html
 #io.personium.core.cell.authorizationhtmlurl.default=
+#io.personium.core.cell.authorizationpasswordchangehtmlurl.default=
 
 # lock general configurations (set milliseconds)
 io.personium.core.lock.retry.times=50
@@ -102,6 +103,12 @@ io.personium.core.masterToken=
 #io.personium.core.security.secret16=changeme
 #io.personium.core.security.auth.password.salt=changeme
 io.personium.core.security.auth.password.regex=^[a-zA-Z0-9-_!$*=^`{|}~.@]{6,32}$
+io.personium.core.security.auth.password.hashAlgorithm=SCrypt
+io.personium.core.security.auth.password.scrypt.cpuCost=16384
+io.personium.core.security.auth.password.scrypt.memoryCost=8
+io.personium.core.security.auth.password.scrypt.parallelization=1
+io.personium.core.security.auth.password.scrypt.keyLength=32
+io.personium.core.security.auth.password.scrypt.saltLength=64
 io.personium.core.security.dav.encrypt.enabled=false
 
 # X509 Certificate file in PEM format

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthHashPasswordTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthHashPasswordTest.java
@@ -1,0 +1,233 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.jersey.cell.auth;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.PersoniumUnitConfig.Security;
+import io.personium.core.auth.hash.SCryptHashPasswordImpl;
+import io.personium.core.auth.hash.Sha256HashPasswordImpl;
+import io.personium.core.model.lock.LockManager;
+import io.personium.core.rs.PersoniumCoreApplication;
+import io.personium.test.categories.Integration;
+import io.personium.test.categories.Regression;
+import io.personium.test.categories.Unit;
+import io.personium.test.jersey.PersoniumIntegTestRunner;
+import io.personium.test.jersey.PersoniumTest;
+import io.personium.test.setup.Setup;
+import io.personium.test.utils.AccountUtils;
+import io.personium.test.utils.CellUtils;
+import io.personium.test.utils.Http;
+import io.personium.test.utils.TResponse;
+import io.personium.test.utils.UserDataUtils;
+
+/**
+ * valid ip address range test.
+ */
+@RunWith(PersoniumIntegTestRunner.class)
+@Category({Unit.class, Integration.class, Regression.class})
+public class AuthHashPasswordTest extends PersoniumTest {
+
+    /** test cell name. */
+    private static final String TEST_CELL = "testcellipaddress";
+
+    /** key name. */
+    private static final String KEY_NAME = "name";
+    /** key password. */
+    private static final String KEY_PASS = "pass";
+
+    private static String defHashArgorithm;
+    private static String defSCryptCpuCost;
+    private static String defSCryptMemoryCost;
+    private static String defSCryptParallelization;
+    private static String defSCryptKeyLength;
+    private static String defSCryptSaltLength;
+    private static String defPasswordRegex;
+
+    /**
+     * Befor class.
+     */
+    @BeforeClass
+    public static void beforClass() {
+        defHashArgorithm = PersoniumUnitConfig.getAuthPasswordHashAlgorithm();
+        defSCryptCpuCost = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_CPUCOST);
+        defSCryptMemoryCost = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST);
+        defSCryptParallelization = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION);
+        defSCryptKeyLength = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH);
+        defSCryptSaltLength = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH);
+        defPasswordRegex = PersoniumUnitConfig.getAuthPasswordRegex();
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_REGEX, "^.*[A-Za-z0-9]$");
+    }
+
+    /**
+     * After class.
+     */
+    @AfterClass
+    public static void afterClass() {
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_HASH_ALGORITHM, defHashArgorithm);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_CPUCOST, defSCryptCpuCost);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST, defSCryptMemoryCost);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION, defSCryptParallelization);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH, defSCryptKeyLength);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH, defSCryptSaltLength);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_REGEX, defPasswordRegex);
+    }
+
+    /**
+     * before.
+     */
+    @Before
+    public void before() {
+        LockManager.deleteAllLocks();
+        CellUtils.create(TEST_CELL, Setup.MASTER_TOKEN_NAME, HttpStatus.SC_CREATED);
+    }
+
+    /**
+     * after.
+     */
+    @After
+    public void after() {
+        LockManager.deleteAllLocks();
+        CellUtils.delete(Setup.MASTER_TOKEN_NAME, TEST_CELL, -1);
+    }
+
+    /**
+     * constructor.
+     */
+    public AuthHashPasswordTest() {
+        super(new PersoniumCoreApplication());
+    }
+
+    /**
+     * Test hash password.
+     */
+    @Test
+    public final void testHashPassword() {
+        List<Map<String, String>> testAccountList = new ArrayList<>();
+        try {
+            // create test accounts.
+            // SHA-256
+            testAccountList.add(createTestAccount(
+                    Sha256HashPasswordImpl.HASH_ALGORITHM_NAME, "test1", "password"));
+            testAccountList.add(createTestAccount(
+                    Sha256HashPasswordImpl.HASH_ALGORITHM_NAME, "test2", UserDataUtils.createString(256)));
+            // SCrypt (defalut params)
+            testAccountList.add(createTestAccount(
+                    SCryptHashPasswordImpl.HASH_ALGORITHM_NAME, "test3", "password"));
+            testAccountList.add(createTestAccount(
+                    SCryptHashPasswordImpl.HASH_ALGORITHM_NAME, "test4", UserDataUtils.createString(256)));
+            // SCrypt (edit params)
+            changeSCryptParams("65536", "32", "2", "256", "128");
+            testAccountList.add(createTestAccount(
+                    SCryptHashPasswordImpl.HASH_ALGORITHM_NAME, "test5", "password"));
+            testAccountList.add(createTestAccount(
+                    SCryptHashPasswordImpl.HASH_ALGORITHM_NAME, "test6", UserDataUtils.createString(256)));
+            changeSCryptParams(defSCryptCpuCost, defSCryptMemoryCost, defSCryptParallelization, defSCryptKeyLength,
+                    defSCryptSaltLength);
+
+            // execute authentication
+            for (Map<String, String> testAccount : testAccountList) {
+                // success
+                String name = testAccount.get(KEY_NAME);
+                String pass = testAccount.get(KEY_PASS);
+                requestAuthentication(TEST_CELL, name, pass, HttpStatus.SC_OK);
+
+                // error (Password mismatch)
+                AuthTestCommon.waitForIntervalLock();
+                String errorPass = pass.substring(0, pass.length() - 1);
+                requestAuthentication(TEST_CELL, name, errorPass, HttpStatus.SC_BAD_REQUEST);
+                AuthTestCommon.waitForIntervalLock();
+                errorPass = pass + "e";
+                requestAuthentication(TEST_CELL, name, errorPass, HttpStatus.SC_BAD_REQUEST);
+            }
+        } finally {
+            // delete test account.
+            for (Map<String, String> testAccount : testAccountList) {
+                String name = testAccount.get(KEY_NAME);
+                AccountUtils.delete(TEST_CELL, Setup.MASTER_TOKEN_NAME, name, -1);
+            }
+        }
+    }
+
+    /**
+     * create test account.
+     * @param hashArgorithm hash argorithm
+     * @param name account name
+     * @param pass password
+     * @return map (key is "name" and "pass")
+     */
+    private Map<String, String> createTestAccount(String hashArgorithm, String name, String pass) {
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_HASH_ALGORITHM, hashArgorithm);
+        AccountUtils.create(Setup.MASTER_TOKEN_NAME, TEST_CELL, name, pass, HttpStatus.SC_CREATED);
+
+        Map<String, String> map = new HashMap<>();
+        map.put(KEY_NAME, name);
+        map.put(KEY_PASS, pass);
+        return map;
+    }
+
+    /**
+     * change SCrypt params.
+     * @param cc SCrypt cpu cost
+     * @param mc SCrypt memory cost
+     * @param p SCrypt parallelization
+     * @param kLen SCrypt key length
+     * @param sLen SCrypt salt length
+     */
+    private void changeSCryptParams(String cc, String mc, String p, String kLen, String sLen) {
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_CPUCOST, cc);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST, mc);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION, p);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH, kLen);
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH, sLen);
+    }
+    /**
+     * @param hashArgorithm hash argorithm
+     * @param name account name
+     * @param pass password
+     * @return map (key is "name" and "pass")
+     */
+    /**
+     * request authentication.
+     * @param cellName cell name
+     * @param userName user name
+     * @param pass password
+     * @param code expected status code
+     * @return http response
+     */
+    private TResponse requestAuthentication(String cellName, String userName, String pass, int code) {
+        Http request = Http.request("authn/password-cl-c0.txt")
+                .with("remoteCell", cellName)
+                .with("username", userName)
+                .with("password", pass);
+        TResponse passRes = request.returns().statusCode(code);
+        return passRes;
+    }
+}

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthHashPasswordTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthHashPasswordTest.java
@@ -208,12 +208,7 @@ public class AuthHashPasswordTest extends PersoniumTest {
         PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH, kLen);
         PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH, sLen);
     }
-    /**
-     * @param hashArgorithm hash argorithm
-     * @param name account name
-     * @param pass password
-     * @return map (key is "name" and "pass")
-     */
+
     /**
      * request authentication.
      * @param cellName cell name

--- a/src/test/java/io/personium/test/jersey/cell/ctl/hashpassword/SCryptHashPasswordTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/ctl/hashpassword/SCryptHashPasswordTest.java
@@ -1,0 +1,329 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.jersey.cell.ctl.hashpassword;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import org.apache.http.HttpStatus;
+import org.json.simple.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+//import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.odata4j.core.ODataConstants;
+import org.odata4j.core.ODataVersion;
+
+import io.personium.common.utils.PersoniumCoreUtils;
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.PersoniumUnitConfig.Security;
+import io.personium.core.auth.OAuth2Helper;
+import io.personium.core.auth.hash.SCryptHashPasswordImpl;
+import io.personium.core.model.lock.LockManager;
+import io.personium.core.rs.PersoniumCoreApplication;
+import io.personium.test.categories.Integration;
+import io.personium.test.categories.Regression;
+import io.personium.test.categories.Unit;
+import io.personium.test.jersey.AbstractCase;
+import io.personium.test.jersey.ODataCommon;
+import io.personium.test.jersey.PersoniumException;
+import io.personium.test.jersey.PersoniumResponse;
+import io.personium.test.jersey.PersoniumRestAdapter;
+import io.personium.test.unit.core.UrlUtils;
+import io.personium.test.utils.AccountUtils;
+import io.personium.test.utils.Http;
+import io.personium.test.utils.TResponse;
+
+/**
+ * test SCrypt hash password.
+ */
+@Category({Unit.class, Integration.class, Regression.class})
+public class SCryptHashPasswordTest extends ODataCommon {
+
+    static String cellName = "testcell1";
+
+    /** Default value of hashArgorithm. */
+    private static String defaultHashArgorithm;
+
+    /**
+     * Befor class.
+     */
+    @BeforeClass
+    public static void beforClass() {
+        defaultHashArgorithm = PersoniumUnitConfig.getAuthPasswordHashAlgorithm();
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_HASH_ALGORITHM, SCryptHashPasswordImpl.HASH_ALGORITHM_NAME);
+    }
+
+    /**
+     * After class.
+     */
+    @AfterClass
+    public static void afterClass() {
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_HASH_ALGORITHM, defaultHashArgorithm);
+    }
+
+    /**
+     * after.
+     */
+    @After
+    public void after() {
+        LockManager.deleteAllLocks();
+    }
+
+    /**
+     * constructor.
+     */
+    public SCryptHashPasswordTest() {
+        super(new PersoniumCoreApplication());
+    }
+
+    /**
+     * test create account.
+     */
+    @Test
+    public final void create_account() {
+        // chang password regex pattern.
+        String defaultPasswordRegex = PersoniumUnitConfig.getAuthPasswordRegex();
+        PersoniumUnitConfig.set(PersoniumUnitConfig.Security.AUTH_PASSWORD_REGEX, "^.*[a-zA-Z0-9]$");
+
+        String testAccountName = "account_hashpassword";
+
+        ArrayList<String> normalPasswordList = new ArrayList<String>();
+        normalPasswordList.add("A");
+        normalPasswordList.add("ABC");
+        normalPasswordList.add("ABCXYZabcxyz0123456789");
+        normalPasswordList.add("12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "ABCDEF");
+
+        try {
+            for (String value : normalPasswordList) {
+                createAccount(testAccountName, value, HttpStatus.SC_CREATED);
+                AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+            }
+        } finally {
+            AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+            PersoniumUnitConfig.set(PersoniumUnitConfig.Security.AUTH_PASSWORD_REGEX, defaultPasswordRegex);
+        }
+    }
+
+    /**
+     * test set scrypt parameter.
+     * Note that invalid values ​​are excluded from testing because they are checked at startup.
+     */
+    @Test
+    public final void test_scrypt_params() {
+        String defCc = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_CPUCOST);
+        String defMc = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST);
+        String defP = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION);
+        String defKlen = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH);
+        String defSlen = PersoniumUnitConfig.get(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH);
+
+        String testAccountName = "account_hashpassword_scrypt_params_";
+        String testPassword = "testPassword";
+
+        int counter = 0;
+        try {
+            // cpu cost: must be power of 2 greater than 1. Default is currently 16384 or 2^14)
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_CPUCOST, "8192");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_CPUCOST, "32768");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_CPUCOST, defCc);
+
+            // memory cost
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST, "4");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST, "16");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST, defMc);
+
+            // parallelization
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION, "2");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION, "3");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION, defP);
+
+            // keyLength
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH, "16");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH, "64");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH, defKlen);
+
+            // saltLength
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH, "32");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH, "128");
+            createAccount(testAccountName + counter, testPassword, HttpStatus.SC_CREATED);
+            counter++;
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH, defSlen);
+
+        } finally {
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_CPUCOST, defCc);
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_MEMORYCOST, defMc);
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_PARALLELIZATION, defP);
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_KEYLENGTH, defKlen);
+            PersoniumUnitConfig.set(Security.AUTH_PASSWORD_SCRYPT_SALTLENGTH, defSlen);
+            for (int i = 0; i < counter; i++) {
+                AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName + i, -1);
+            }
+        }
+    }
+
+    /**
+     * test update account password.
+     */
+    @Test
+    public final void update_account_password() {
+        String testAccountName = "account_hashpassword_update";
+
+        String oldPassword = "old_p@ssword0";
+        String newPassword = "new_p@ssword0";
+
+        try {
+            // create test account.
+            createAccount(testAccountName, oldPassword, HttpStatus.SC_CREATED);
+            this.auth(testAccountName, oldPassword, HttpStatus.SC_OK);
+
+            // update password.
+            this.updatePwd(testAccountName, newPassword, HttpStatus.SC_NO_CONTENT);
+            this.auth(testAccountName, newPassword, HttpStatus.SC_OK);
+            this.auth(testAccountName, oldPassword, HttpStatus.SC_BAD_REQUEST);
+        } finally {
+            AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+        }
+    }
+
+    /**
+     * test change my password.
+     */
+    @Test
+    public final void change_my_password() {
+        String testAccountName = "account_hashpassword_update";
+
+        String oldPassword = "old_p@ssword0";
+        String newPassword = "new_p@ssword0";
+
+        try {
+            // create test account.
+            createAccount(testAccountName, oldPassword, HttpStatus.SC_CREATED);
+            JSONObject resBody = this.auth(testAccountName, oldPassword, HttpStatus.SC_OK);
+            String tokenStr = (String) resBody.get(OAuth2Helper.Key.ACCESS_TOKEN);
+
+            // request my password. (change my password)
+            this.requestMyPassword(tokenStr, newPassword, HttpStatus.SC_NO_CONTENT);
+            this.auth(testAccountName, newPassword, HttpStatus.SC_OK);
+            this.auth(testAccountName, oldPassword, HttpStatus.SC_BAD_REQUEST);
+        } finally {
+            AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+        }
+    }
+
+    private String createAccount(String testAccountName, String testAccountPass, int code) {
+        String accLocHeader;
+        TResponse res = Http.request("account-create.txt")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("cellPath", cellName)
+                .with("username", testAccountName)
+                .with("password", testAccountPass)
+                .returns()
+                .debug();
+        accLocHeader = res.getLocationHeader();
+        res.statusCode(code);
+        return accLocHeader;
+    }
+
+    /**
+     * account update. (password only)
+     * @param newUsername アカウント名
+     * @param newPassword パスワード
+     * @param sc ステータスコード
+     */
+    private void updatePwd(String username, String newPassword, int sc) {
+        TResponse res = Http.request("account-update.txt")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("cellPath", cellName)
+                .with("username", username)
+                .with("password", newPassword)
+                .with("newUsername", username)
+                .returns().debug();
+        res.statusCode(sc);
+        res.checkHeader(ODataConstants.Headers.DATA_SERVICE_VERSION, ODataVersion.V2.asString);
+    }
+
+    /**
+     * request mypassword.
+     * @param headerAuthorization access token.
+     * @param headerCredential new password
+     * @param sc status code
+     * @return response
+     */
+    private PersoniumResponse requestMyPassword(String headerAuthorization, String headerCredential, int sc) {
+        PersoniumRestAdapter rest = new PersoniumRestAdapter();
+        PersoniumResponse res = null;
+
+        // リクエストヘッダをセット
+        HashMap<String, String> requestheaders = new HashMap<String, String>();
+        requestheaders.put(HttpHeaders.AUTHORIZATION, "Bearer " + headerAuthorization);
+        requestheaders.put(PersoniumCoreUtils.HttpHeaders.X_PERSONIUM_CREDENTIAL, headerCredential);
+
+        try {
+            res = rest.put(UrlUtils.cellRoot(cellName) + "__mypassword", "", requestheaders);
+        } catch (PersoniumException e) {
+            e.printStackTrace();
+        }
+        assertEquals(sc, res.getStatusCode());
+        return res;
+    }
+
+    /**
+     * password authentication.
+     * @param usr account name
+     * @param pwd password
+     * @param sc status code
+     */
+    private JSONObject auth(String usr, String pwd, int sc) {
+        TResponse res = Http.request("authn/password-cl-c0.txt")
+                .with("remoteCell", cellName)
+                .with("username", usr)
+                .with("password", pwd)
+                .returns();
+        res.statusCode(sc);
+        JSONObject json = res.bodyAsJson();
+        return json;
+    }
+}

--- a/src/test/java/io/personium/test/jersey/cell/ctl/hashpassword/Sha256HashPasswordTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/ctl/hashpassword/Sha256HashPasswordTest.java
@@ -1,0 +1,256 @@
+/**
+ * personium.io
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.jersey.cell.ctl.hashpassword;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import org.apache.http.HttpStatus;
+import org.json.simple.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+//import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.odata4j.core.ODataConstants;
+import org.odata4j.core.ODataVersion;
+
+import io.personium.common.utils.PersoniumCoreUtils;
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.PersoniumUnitConfig.Security;
+import io.personium.core.auth.OAuth2Helper;
+import io.personium.core.auth.hash.Sha256HashPasswordImpl;
+import io.personium.core.model.lock.LockManager;
+import io.personium.core.rs.PersoniumCoreApplication;
+import io.personium.test.categories.Integration;
+import io.personium.test.categories.Regression;
+import io.personium.test.categories.Unit;
+import io.personium.test.jersey.AbstractCase;
+import io.personium.test.jersey.ODataCommon;
+import io.personium.test.jersey.PersoniumException;
+import io.personium.test.jersey.PersoniumResponse;
+import io.personium.test.jersey.PersoniumRestAdapter;
+import io.personium.test.unit.core.UrlUtils;
+import io.personium.test.utils.AccountUtils;
+import io.personium.test.utils.Http;
+import io.personium.test.utils.TResponse;
+
+/**
+ * test SHA-256 hash password.
+ */
+@Category({Unit.class, Integration.class, Regression.class})
+public class Sha256HashPasswordTest extends ODataCommon {
+
+    static String cellName = "testcell1";
+
+    /** Default value of hashArgorithm. */
+    private static String defaultHashArgorithm;
+
+    /**
+     * Befor class.
+     */
+    @BeforeClass
+    public static void beforClass() {
+        defaultHashArgorithm = PersoniumUnitConfig.getAuthPasswordHashAlgorithm();
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_HASH_ALGORITHM, Sha256HashPasswordImpl.HASH_ALGORITHM_NAME);
+    }
+
+    /**
+     * After class.
+     */
+    @AfterClass
+    public static void afterClass() {
+        PersoniumUnitConfig.set(Security.AUTH_PASSWORD_HASH_ALGORITHM, defaultHashArgorithm);
+    }
+
+    /**
+     * after.
+     */
+    @After
+    public void after() {
+        LockManager.deleteAllLocks();
+    }
+
+    /**
+     * constructor.
+     */
+    public Sha256HashPasswordTest() {
+        super(new PersoniumCoreApplication());
+    }
+
+    /**
+     * test create account.
+     */
+    @Test
+    public final void create_account() {
+        // chang password regex pattern.
+        String defaultPasswordRegex = PersoniumUnitConfig.getAuthPasswordRegex();
+        PersoniumUnitConfig.set(PersoniumUnitConfig.Security.AUTH_PASSWORD_REGEX,
+                "(?=.*[A-Z])(?!^(?i)password(?-i)$)^.*[a-zA-Z0-9]$");
+
+        String testAccountName = "account_hashpassword";
+
+        ArrayList<String> normalPasswordList = new ArrayList<String>();
+        normalPasswordList.add("A");
+        normalPasswordList.add("ABC");
+        normalPasswordList.add("ABCXYZabcxyz0123456789");
+        normalPasswordList.add("12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "12345678901234567890123456789012345678901234567890"
+                + "ABCDEF");
+
+        try {
+            for (String value : normalPasswordList) {
+                createAccount(testAccountName, value, HttpStatus.SC_CREATED);
+                AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+            }
+        } finally {
+            AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+            PersoniumUnitConfig.set(PersoniumUnitConfig.Security.AUTH_PASSWORD_REGEX, defaultPasswordRegex);
+        }
+    }
+
+    /**
+     * test update account password.
+     */
+    @Test
+    public final void update_account_password() {
+        String testAccountName = "account_hashpassword_update";
+
+        String oldPassword = "old_p@ssword0";
+        String newPassword = "new_p@ssword0";
+
+        try {
+            // create test account.
+            createAccount(testAccountName, oldPassword, HttpStatus.SC_CREATED);
+            this.auth(testAccountName, oldPassword, HttpStatus.SC_OK);
+
+            // update password.
+            this.updatePwd(testAccountName, newPassword, HttpStatus.SC_NO_CONTENT);
+            this.auth(testAccountName, newPassword, HttpStatus.SC_OK);
+            this.auth(testAccountName, oldPassword, HttpStatus.SC_BAD_REQUEST);
+        } finally {
+            AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+        }
+    }
+
+    /**
+     * test change my password.
+     */
+    @Test
+    public final void change_my_password() {
+        String testAccountName = "account_hashpassword_update";
+
+        String oldPassword = "old_p@ssword0";
+        String newPassword = "new_p@ssword0";
+
+        try {
+            // create test account.
+            createAccount(testAccountName, oldPassword, HttpStatus.SC_CREATED);
+            JSONObject resBody = this.auth(testAccountName, oldPassword, HttpStatus.SC_OK);
+            String tokenStr = (String) resBody.get(OAuth2Helper.Key.ACCESS_TOKEN);
+
+            // request my password. (change my password)
+            this.requestMyPassword(tokenStr, newPassword, HttpStatus.SC_NO_CONTENT);
+            this.auth(testAccountName, newPassword, HttpStatus.SC_OK);
+            this.auth(testAccountName, oldPassword, HttpStatus.SC_BAD_REQUEST);
+        } finally {
+            AccountUtils.delete(cellName, MASTER_TOKEN_NAME, testAccountName, -1);
+        }
+    }
+
+    private String createAccount(String testAccountName, String testAccountPass, int code) {
+        String accLocHeader;
+        TResponse res = Http.request("account-create.txt")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("cellPath", cellName)
+                .with("username", testAccountName)
+                .with("password", testAccountPass)
+                .returns()
+                .debug();
+        accLocHeader = res.getLocationHeader();
+        res.statusCode(code);
+        return accLocHeader;
+    }
+
+    /**
+     * account update. (password only)
+     * @param newUsername アカウント名
+     * @param newPassword パスワード
+     * @param sc ステータスコード
+     */
+    private void updatePwd(String username, String newPassword, int sc) {
+        TResponse res = Http.request("account-update.txt")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("cellPath", cellName)
+                .with("username", username)
+                .with("password", newPassword)
+                .with("newUsername", username)
+                .returns().debug();
+        res.statusCode(sc);
+        res.checkHeader(ODataConstants.Headers.DATA_SERVICE_VERSION, ODataVersion.V2.asString);
+    }
+
+    /**
+     * request mypassword.
+     * @param headerAuthorization access token.
+     * @param headerCredential new password
+     * @param sc status code
+     * @return response
+     */
+    private PersoniumResponse requestMyPassword(String headerAuthorization, String headerCredential, int sc) {
+        PersoniumRestAdapter rest = new PersoniumRestAdapter();
+        PersoniumResponse res = null;
+
+        // set request header
+        HashMap<String, String> requestheaders = new HashMap<String, String>();
+        requestheaders.put(HttpHeaders.AUTHORIZATION, "Bearer " + headerAuthorization);
+        requestheaders.put(PersoniumCoreUtils.HttpHeaders.X_PERSONIUM_CREDENTIAL, headerCredential);
+
+        try {
+            res = rest.put(UrlUtils.cellRoot(cellName) + "__mypassword", "", requestheaders);
+        } catch (PersoniumException e) {
+            e.printStackTrace();
+        }
+        assertEquals(sc, res.getStatusCode());
+        return res;
+    }
+
+    /**
+     * password authentication.
+     * @param usr account name
+     * @param pwd password
+     * @param sc status code
+     */
+    private JSONObject auth(String usr, String pwd, int sc) {
+        TResponse res = Http.request("authn/password-cl-c0.txt")
+                .with("remoteCell", cellName)
+                .with("username", usr)
+                .with("password", pwd)
+                .returns();
+        res.statusCode(sc);
+        JSONObject json = res.bodyAsJson();
+        return json;
+    }
+}


### PR DESCRIPTION
- Compatible with SCrypt.
- Prevent the existence of account from being detected by processing time.