### PR TITLE
Correction about RequestKey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>io.personium</groupId>
     <artifactId>personium-core</artifactId>
     <packaging>war</packaging>
-    <version>1.7.10_es6.6.1</version>
+    <version>1.7.11_es6.6.1-SNAPSHOT</version>
     <name>personium-core Maven Webapp</name>
     <url>http://maven.apache.org</url>
     <licenses>

--- a/src/main/java/io/personium/core/rs/FacadeResource.java
+++ b/src/main/java/io/personium/core/rs/FacadeResource.java
@@ -83,6 +83,18 @@ public class FacadeResource {
             @Context final UriInfo uriInfo,
             @Context HttpServletRequest httpServletRequest) {
 
+        if (log.isDebugEnabled()) {
+            log.debug("Call API '" + uriInfo.getAbsolutePath().toString() + "'.");
+            log.debug("    p_cookie: " + cookieAuthValue);
+            log.debug("    p_cookie_peer: " + cookiePeer);
+            log.debug("    Authorization: " + headerAuthz);
+            log.debug("    X-Personium-Unit-User: " + headerPersoniumUnitUser);
+            log.debug("    X-Personium-RequestKey: " + headerPersoniumRequestKey);
+            log.debug("    X-Personium-EventId: " + headerPersoniumEventId);
+            log.debug("    X-Personium-RuleChain: " + headerPersoniumRuleChain);
+            log.debug("    X-Personium-Via: " + headerPersoniumVia);
+        }
+
         if (PersoniumUnitConfig.isPathBasedCellUrlEnabled()) {
             return new UnitResource(cookieAuthValue, cookiePeer, headerAuthz, headerHost,
                     headerPersoniumUnitUser, uriInfo);
@@ -110,10 +122,11 @@ public class FacadeResource {
 
             CellLockManager.incrementReferenceCount(cell.getId());
             httpServletRequest.setAttribute("cellId", cell.getId());
-            if (headerPersoniumRequestKey != null) {
-                ResourceUtils.validateXPersoniumRequestKey(headerPersoniumRequestKey);
+            String requestKey = ResourceUtils.validateXPersoniumRequestKey(headerPersoniumRequestKey);
+            if (headerPersoniumRequestKey == null) {
+                log.debug("    Create RequestKey: " + requestKey);
             }
-            return new CellResource(ac, headerPersoniumRequestKey,
+            return new CellResource(ac, requestKey,
                     headerPersoniumEventId, headerPersoniumRuleChain, headerPersoniumVia, httpServletRequest);
         }
     }

--- a/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
+++ b/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
@@ -71,6 +71,7 @@ import io.personium.core.auth.BoxPrivilege;
 import io.personium.core.event.EventBus;
 import io.personium.core.event.PersoniumEvent;
 import io.personium.core.event.PersoniumEventType;
+import io.personium.core.model.CellRsCmp;
 import io.personium.core.model.DavCmp;
 import io.personium.core.model.DavMoveResource;
 import io.personium.core.model.DavRsCmp;
@@ -464,6 +465,14 @@ public class PersoniumEngineSvcCollectionResource {
             }
         }
 
+        // If RequestKey is not specified in the header, Take over the generated RequestKey.
+        if (!req.containsHeader(PersoniumCoreUtils.HttpHeaders.X_PERSONIUM_REQUESTKEY)) {
+            String requestKey = this.getRequestKey(this.davRsCmp);
+            if (requestKey != null) {
+                req.addHeader(PersoniumCoreUtils.HttpHeaders.X_PERSONIUM_REQUESTKEY, requestKey);
+            }
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("[EngineRelay]" + req.getMethod() + " " + req.getURI());
             Header[] reqHeaders = req.getAllHeaders();
@@ -556,6 +565,24 @@ public class PersoniumEngineSvcCollectionResource {
 
         //Response return
         return res.build();
+    }
+
+    /**
+     * get request key. (For when not specified in the header)
+     * @param rsCmp DavRsCmp
+     * @return request key
+     */
+    private String getRequestKey(DavRsCmp rsCmp) {
+        if (rsCmp == null) {
+            return null;
+        }
+        if (rsCmp instanceof CellRsCmp) {
+            return ((CellRsCmp) rsCmp).getRequestKey();
+        }
+        if (rsCmp.getParent() == null) {
+            return null;
+        }
+        return getRequestKey(rsCmp);
     }
 
     /**

--- a/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
+++ b/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
@@ -403,7 +403,7 @@ public class PersoniumEngineSvcCollectionResource {
      * @param is Request body
      * @return JAX-RS Response
      */
-    private Response relaycommon(
+    private Response relaycommon( // CHECKSTYLE IGNORE - Necessary processing
             String method,
             UriInfo uriInfo,
             String path,

--- a/src/main/java/io/personium/core/rs/unit/UnitResource.java
+++ b/src/main/java/io/personium/core/rs/unit/UnitResource.java
@@ -30,6 +30,8 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.codec.CharEncoding;
 import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.personium.common.utils.PersoniumCoreUtils;
 import io.personium.core.PersoniumCoreException;
@@ -46,6 +48,7 @@ import io.personium.core.utils.ResourceUtils;
  * Jax-RS Resource handling Personium Unit Level API.
  */
 public class UnitResource {
+    private static Logger log = LoggerFactory.getLogger(UnitResource.class);
 
     /** Cookie : p_cookie. */
     private String cookieAuthValue;
@@ -133,10 +136,11 @@ public class UnitResource {
 
         CellLockManager.incrementReferenceCount(cell.getId());
         httpServletRequest.setAttribute("cellId", cell.getId());
-        if (xPersoniumRequestKey != null) {
-            ResourceUtils.validateXPersoniumRequestKey(xPersoniumRequestKey);
+        String requestKey = ResourceUtils.validateXPersoniumRequestKey(xPersoniumRequestKey);
+        if (xPersoniumRequestKey == null) {
+            log.debug("    Create RequestKey: " + requestKey);
         }
-        return new CellResource(ac, xPersoniumRequestKey,
+        return new CellResource(ac, requestKey,
                 xPersoniumEventId, xPersoniumRuleChain, xPersoniumVia, httpServletRequest);
     }
 

--- a/src/main/java/io/personium/core/utils/ResourceUtils.java
+++ b/src/main/java/io/personium/core/utils/ResourceUtils.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -161,7 +162,7 @@ public class ResourceUtils {
     }
 
     static final int MAXREQUEST_KEY_LENGTH = 128;
-    static final String REQEUST_KEY_DEFAULT_FORMAT = "PCS-%d";
+    static final String REQEUST_KEY_DEFAULT_FORMAT = "PCS-%s";
     static final Pattern REQUEST_KEY_PATTERN = Pattern.compile("[\\p{Alpha}\\p{Digit}_-]*");
 
     /**
@@ -173,7 +174,7 @@ public class ResourceUtils {
      */
     public static String validateXPersoniumRequestKey(String requestKey) {
         if (null == requestKey) {
-            requestKey = String.format(REQEUST_KEY_DEFAULT_FORMAT, System.currentTimeMillis());
+            requestKey = String.format(REQEUST_KEY_DEFAULT_FORMAT, UUID.randomUUID().toString());
         }
         if (MAXREQUEST_KEY_LENGTH < requestKey.length()) {
             throw PersoniumCoreException.Event.X_PERSONIUM_REQUESTKEY_INVALID;

--- a/src/main/resources/personium-unit-config-default.properties
+++ b/src/main/resources/personium-unit-config-default.properties
@@ -23,7 +23,7 @@
 #################################################
 
 # core version
-io.personium.core.version=1.7.10
+io.personium.core.version=1.7.11
 
 # thread pool num.
 io.personium.core.thread.pool.num.io.cell=10

--- a/src/test/java/io/personium/core/utils/ResourceUtilsTest.java
+++ b/src/test/java/io/personium/core/utils/ResourceUtilsTest.java
@@ -100,8 +100,7 @@ public class ResourceUtilsTest {
     public void validateXPersoniumRequestKey_Normal_key_is_null() {
         String result = ResourceUtils.validateXPersoniumRequestKey(null);
         assertTrue(result.startsWith("PCS-"));
-        String timeStr = result.substring(4);
-        Long.parseLong(timeStr);
+        assertTrue(result.length() == 40);
     }
 
     /**

--- a/src/test/java/io/personium/test/jersey/box/ServiceRelayTest.java
+++ b/src/test/java/io/personium/test/jersey/box/ServiceRelayTest.java
@@ -79,7 +79,8 @@ public class ServiceRelayTest extends PersoniumTest {
             "host",
             "connection",
             "authorization",
-            "user-agent"};
+            "user-agent",
+            "X-Personium-RequestKey"};
 
     /**
      * 事前準備.


### PR DESCRIPTION
- RequestKey etc. are output to DEBUG log when calling API.
- Modified to generate RequestKey as much as possible at the time of API call (However, regarding Unit Level API, it was not possible to cope with the logic.)
- Change default value of RequestKey
- When relaying to Engine, fixed RequestKey to be taken over.