### PR TITLE
Concurrent request support for App cell.

### DIFF
--- a/src/main/java/io/personium/core/PersoniumCoreException.java
+++ b/src/main/java/io/personium/core/PersoniumCoreException.java
@@ -869,6 +869,10 @@ public class PersoniumCoreException extends RuntimeException {
          */
         public static final PersoniumCoreException PROPERTY_NOT_URL = create("PR412-UI-0002");
         /**
+         * Property settings error. [{0}] // CHECKSTYLE IGNORE - To maintain readability
+         */
+        public static final PersoniumCoreException PROPERTY_SETTINGS_ERROR = create("PR412-UI-0003");
+        /**
          * Invalid HTTP response was returned.<p>
          * Invalid HTTP response was returned from {0}.
          */

--- a/src/main/java/io/personium/core/model/CellRsCmp.java
+++ b/src/main/java/io/personium/core/model/CellRsCmp.java
@@ -323,11 +323,10 @@ public class CellRsCmp extends DavRsCmp {
 
 
     /**
-     * Request get not to recording authentication history accounts.
+     * Request get accounts not to recording authentication history.
      * @return Http response
      */
-    public List<String> requestGetAccountsNotRecordingAuthHistory() {
-        // Get not to recording auth accounts.
+    public List<String> getAccountsNotRecordingAuthHistory() {
         String accountsStr;
         try {
             accountsStr = getDavCmp().getProperty(

--- a/src/main/java/io/personium/core/model/CellRsCmp.java
+++ b/src/main/java/io/personium/core/model/CellRsCmp.java
@@ -19,6 +19,8 @@ package io.personium.core.model;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -52,6 +54,8 @@ public class CellRsCmp extends DavRsCmp {
     private static final String AUTHORIZATION_HTML_URL = "authorizationhtmlurl";
     /** Name of property in which the URL of the authorization html. */
     private static final String AUTHORIZATION_PASSWORD_CHANGE_HTML_URL = "authorizationpasswordchangehtmlurl";
+    /** Not to recording authentication history accounts. */
+    private static final String NOT_TO_RECORDING_AUTH_HISTORY_ACCOUNTS = "nottorecordingauthhistoryaccounts";
 
     Cell cell;
     AccessContext accessContext;
@@ -315,6 +319,27 @@ public class CellRsCmp extends DavRsCmp {
         } catch (URISyntaxException e) {
             throw PersoniumCoreException.UI.PROPERTY_NOT_URL.params(propertyName);
         }
+    }
+
+
+    /**
+     * Request get not to recording authentication history accounts.
+     * @return Http response
+     */
+    public List<String> requestGetNotToRecordingAuthHistoryAccounts() {
+        // Get not to recording auth accounts.
+        String accountsStr;
+        try {
+            accountsStr = getDavCmp().getProperty(
+                    NOT_TO_RECORDING_AUTH_HISTORY_ACCOUNTS, "urn:x-personium:xmlns");
+        } catch (IOException | SAXException e1) {
+            throw PersoniumCoreException.UI.PROPERTY_SETTINGS_ERROR.params(NOT_TO_RECORDING_AUTH_HISTORY_ACCOUNTS);
+        }
+        if (StringUtils.isEmpty(accountsStr)) {
+            return null;
+        }
+        String[] accounts = accountsStr.split(",");
+        return Arrays.asList(accounts);
     }
 
     /**

--- a/src/main/java/io/personium/core/model/CellRsCmp.java
+++ b/src/main/java/io/personium/core/model/CellRsCmp.java
@@ -54,8 +54,8 @@ public class CellRsCmp extends DavRsCmp {
     private static final String AUTHORIZATION_HTML_URL = "authorizationhtmlurl";
     /** Name of property in which the URL of the authorization html. */
     private static final String AUTHORIZATION_PASSWORD_CHANGE_HTML_URL = "authorizationpasswordchangehtmlurl";
-    /** Not to recording authentication history accounts. */
-    private static final String NOT_TO_RECORDING_AUTH_HISTORY_ACCOUNTS = "nottorecordingauthhistoryaccounts";
+    /** Name of property in accounts not recording authentication history. */
+    private static final String ACCOUNTS_NOT_RECORDING_AUTH_HISTORY = "accountsnotrecordingauthhistory";
 
     Cell cell;
     AccessContext accessContext;
@@ -326,14 +326,14 @@ public class CellRsCmp extends DavRsCmp {
      * Request get not to recording authentication history accounts.
      * @return Http response
      */
-    public List<String> requestGetNotToRecordingAuthHistoryAccounts() {
+    public List<String> requestGetAccountsNotRecordingAuthHistory() {
         // Get not to recording auth accounts.
         String accountsStr;
         try {
             accountsStr = getDavCmp().getProperty(
-                    NOT_TO_RECORDING_AUTH_HISTORY_ACCOUNTS, "urn:x-personium:xmlns");
+                    ACCOUNTS_NOT_RECORDING_AUTH_HISTORY, "urn:x-personium:xmlns");
         } catch (IOException | SAXException e1) {
-            throw PersoniumCoreException.UI.PROPERTY_SETTINGS_ERROR.params(NOT_TO_RECORDING_AUTH_HISTORY_ACCOUNTS);
+            throw PersoniumCoreException.UI.PROPERTY_SETTINGS_ERROR.params(ACCOUNTS_NOT_RECORDING_AUTH_HISTORY);
         }
         if (StringUtils.isEmpty(accountsStr)) {
             return null;

--- a/src/main/java/io/personium/core/rs/cell/AuthResourceUtils.java
+++ b/src/main/java/io/personium/core/rs/cell/AuthResourceUtils.java
@@ -23,7 +23,9 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +33,7 @@ import io.personium.common.auth.token.TransCellAccessToken;
 import io.personium.core.PersoniumUnitConfig;
 import io.personium.core.auth.AuthHistoryLastFile;
 import io.personium.core.model.Cell;
+import io.personium.core.model.CellRsCmp;
 import io.personium.core.model.lock.AccountLockManager;
 import io.personium.core.model.lock.AccountValidAuthnIntervalLockManager;
 import io.personium.core.model.lock.Lock;
@@ -191,6 +194,24 @@ public class AuthResourceUtils {
             log.debug("unlock auth history. accountId:" + accountId);
             lock.release();
         }
+    }
+
+    /**
+     * Check if the target account records authentication history.
+     * @param cellRsCmp cell rs cmp
+     * @param accountId account ID
+     * @param accountName account name
+     * @return "true" is records authentication history
+     */
+    public static boolean isRecordingAuthHistory(CellRsCmp cellRsCmp, String accountId, String accountName) {
+        if (StringUtils.isEmpty(accountId) || StringUtils.isEmpty(accountName)) {
+            return false;
+        }
+        List<String> ineligibleAccountList = cellRsCmp.requestGetNotToRecordingAuthHistoryAccounts();
+        if (ineligibleAccountList == null) {
+            return true;
+        }
+        return !ineligibleAccountList.contains(accountName);
     }
 
     /**

--- a/src/main/java/io/personium/core/rs/cell/AuthResourceUtils.java
+++ b/src/main/java/io/personium/core/rs/cell/AuthResourceUtils.java
@@ -207,7 +207,7 @@ public class AuthResourceUtils {
         if (StringUtils.isEmpty(accountId) || StringUtils.isEmpty(accountName)) {
             return false;
         }
-        List<String> ineligibleAccountList = cellRsCmp.requestGetAccountsNotRecordingAuthHistory();
+        List<String> ineligibleAccountList = cellRsCmp.getAccountsNotRecordingAuthHistory();
         if (ineligibleAccountList == null) {
             return true;
         }

--- a/src/main/java/io/personium/core/rs/cell/AuthResourceUtils.java
+++ b/src/main/java/io/personium/core/rs/cell/AuthResourceUtils.java
@@ -207,7 +207,7 @@ public class AuthResourceUtils {
         if (StringUtils.isEmpty(accountId) || StringUtils.isEmpty(accountName)) {
             return false;
         }
-        List<String> ineligibleAccountList = cellRsCmp.requestGetNotToRecordingAuthHistoryAccounts();
+        List<String> ineligibleAccountList = cellRsCmp.requestGetAccountsNotRecordingAuthHistory();
         if (ineligibleAccountList == null) {
             return true;
         }

--- a/src/main/resources/personium-messages.properties
+++ b/src/main/resources/personium-messages.properties
@@ -336,6 +336,7 @@ io.personium.core.msg.PR500-NW-0003=Unexpected value from key={0}, where "{1}" v
 ## UI
 io.personium.core.msg.PR412-UI-0001=Property [{0}] not configured.
 io.personium.core.msg.PR412-UI-0002=Property settings error. [{0}] should be normalized URL with http(s), personium-localunit and personium-localcell scheme.
+io.personium.core.msg.PR412-UI-0003=Property settings error. [{0}]
 io.personium.core.msg.PR500-UI-0001=Invalid HTTP response was returned from {0}.
 io.personium.core.msg.PR500-UI-0002=Could not connect to {0}.
 

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
@@ -169,17 +169,17 @@ public class AuthHistoryTest extends PersoniumTest {
     }
 
     /**
-     * test nottorecordingauthhistoryaccounts.
+     * test accountsnotrecordingauthhistory.
      */
     @Test
-    public final void not_to_recording_auth_history_accounts() {
+    public final void not_recording_auth_history() {
         String accountNr2 = "accountNr2";
 
         try {
             AccountUtils.create(Setup.MASTER_TOKEN_NAME, TEST_CELL, accountNr2, TEST_PASSWORD,
                     HttpStatus.SC_CREATED);
             CellUtils.proppatchSet(TEST_CELL,
-                    "<p:nottorecordingauthhistoryaccounts>accountNr1,accountNr2</p:nottorecordingauthhistoryaccounts>",
+                    "<p:accountsnotrecordingauthhistory>accountNr1,accountNr2</p:accountsnotrecordingauthhistory>",
                     Setup.MASTER_TOKEN_NAME, HttpStatus.SC_MULTI_STATUS);
 
             // first get token. Authentication history is not recorded.
@@ -215,7 +215,7 @@ public class AuthHistoryTest extends PersoniumTest {
             assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(3L));
         } finally {
             AccountUtils.delete(TEST_CELL, Setup.MASTER_TOKEN_NAME, accountNr2, -1);
-            CellUtils.proppatchRemove(TEST_CELL, "<p:nottorecordingauthhistoryaccounts/>", Setup.MASTER_TOKEN_NAME, -1);
+            CellUtils.proppatchRemove(TEST_CELL, "<p:accountsnotrecordingauthhistory/>", Setup.MASTER_TOKEN_NAME, -1);
         }
     }
 

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthHistoryTest.java
@@ -169,6 +169,57 @@ public class AuthHistoryTest extends PersoniumTest {
     }
 
     /**
+     * test nottorecordingauthhistoryaccounts.
+     */
+    @Test
+    public final void not_to_recording_auth_history_accounts() {
+        String accountNr2 = "accountNr2";
+
+        try {
+            AccountUtils.create(Setup.MASTER_TOKEN_NAME, TEST_CELL, accountNr2, TEST_PASSWORD,
+                    HttpStatus.SC_CREATED);
+            CellUtils.proppatchSet(TEST_CELL,
+                    "<p:nottorecordingauthhistoryaccounts>accountNr1,accountNr2</p:nottorecordingauthhistoryaccounts>",
+                    Setup.MASTER_TOKEN_NAME, HttpStatus.SC_MULTI_STATUS);
+
+            // first get token. Authentication history is not recorded.
+            requestAuthentication(TEST_CELL, accountNr2, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+            requestAuthentication(TEST_CELL, accountNr2, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+            requestAuthentication(TEST_CELL, accountNr2, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+            AuthTestCommon.waitForIntervalLock();
+            TResponse passRes = requestAuthentication(TEST_CELL, accountNr2, TEST_PASSWORD, HttpStatus.SC_OK);
+            assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
+            assertNull(passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED));
+            assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(0L));
+
+            // second get token. Authentication history is not recorded.
+            passRes = requestAuthentication(TEST_CELL, accountNr2, TEST_PASSWORD, HttpStatus.SC_OK);
+            assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
+            assertNull(passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED));
+            assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(0L));
+
+            // third get token. Authentication history is not recorded.
+            requestAuthentication(TEST_CELL, accountNr2, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+            AuthTestCommon.waitForIntervalLock();
+            passRes = requestAuthentication(TEST_CELL, accountNr2, TEST_PASSWORD, HttpStatus.SC_OK);
+            assertTrue(passRes.bodyAsJson().containsKey(OAuth2Helper.Key.LAST_AUTHENTICATED));
+            assertNull(passRes.bodyAsJson().get(OAuth2Helper.Key.LAST_AUTHENTICATED));
+            assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(0L));
+
+            // The authentication history of other accounts is recorded.
+            requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+            requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+            requestAuthentication(TEST_CELL, TEST_ACCOUNT, "dummypassword1", HttpStatus.SC_BAD_REQUEST);
+            AuthTestCommon.waitForIntervalLock();
+            passRes = requestAuthentication(TEST_CELL, TEST_ACCOUNT, TEST_PASSWORD, HttpStatus.SC_OK);
+            assertThat(passRes.bodyAsJson().get(OAuth2Helper.Key.FAILED_COUNT), is(3L));
+        } finally {
+            AccountUtils.delete(TEST_CELL, Setup.MASTER_TOKEN_NAME, accountNr2, -1);
+            CellUtils.proppatchRemove(TEST_CELL, "<p:nottorecordingauthhistoryaccounts/>", Setup.MASTER_TOKEN_NAME, -1);
+        }
+    }
+
+    /**
      * request authentication.
      * @param cellName cell name
      * @param userName user name

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthzGetAuthHistoryTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthzGetAuthHistoryTest.java
@@ -152,18 +152,18 @@ public class AuthzGetAuthHistoryTest extends PersoniumTest {
     }
 
     /**
-     * test nottorecordingauthhistoryaccounts.
+     * test accountsnotrecordingauthhistory.
      * @throws Exception Unexpected exception
      */
     @Test
-    public final void not_to_recording_auth_history_accounts() throws Exception {
+    public final void not_recording_auth_history() throws Exception {
         String accountNr2 = "accountNr2";
 
         try {
             AccountUtils.create(Setup.MASTER_TOKEN_NAME, TEST_CELL, accountNr2, TEST_PASSWORD,
                     HttpStatus.SC_CREATED);
             CellUtils.proppatchSet(TEST_CELL,
-                    "<p:nottorecordingauthhistoryaccounts>accountNr1,accountNr2</p:nottorecordingauthhistoryaccounts>",
+                    "<p:accountsnotrecordingauthhistory>accountNr1,accountNr2</p:accountsnotrecordingauthhistory>",
                     Setup.MASTER_TOKEN_NAME, HttpStatus.SC_MULTI_STATUS);
 
             // first get token. Authentication history is not recorded.
@@ -212,7 +212,7 @@ public class AuthzGetAuthHistoryTest extends PersoniumTest {
             assertThat(responseMap.get(OAuth2Helper.Key.FAILED_COUNT)).contains("3");
         } finally {
             AccountUtils.delete(TEST_CELL, Setup.MASTER_TOKEN_NAME, accountNr2, -1);
-            CellUtils.proppatchRemove(TEST_CELL, "<p:nottorecordingauthhistoryaccounts/>", Setup.MASTER_TOKEN_NAME, -1);
+            CellUtils.proppatchRemove(TEST_CELL, "<p:accountsnotrecordingauthhistory/>", Setup.MASTER_TOKEN_NAME, -1);
         }
     }
 


### PR DESCRIPTION
#398 Concurrent request support for token authentication to the same account(App cell).
- Announce to set the appcell authentication account name to "accountsnotrecordingauthhistory".