### PR TITLE
#370 When a large number of Rules are registered in Unit, it takes time to start personium (tomcat).

### DIFF
--- a/src/main/java/io/personium/core/auth/AuthHistoryLastFile.java
+++ b/src/main/java/io/personium/core/auth/AuthHistoryLastFile.java
@@ -112,6 +112,7 @@ public class AuthHistoryLastFile {
      * load from the file.
      */
     public void load() {
+        log.debug("load started. accountID:" + accountId);
         int retryCount = 0;
         while (true) {
             try {
@@ -133,6 +134,7 @@ public class AuthHistoryLastFile {
                 }
             }
         }
+        log.debug("load ended.");
     }
 
     /**
@@ -152,6 +154,7 @@ public class AuthHistoryLastFile {
      * save to the file.
      */
     public void save() {
+        log.debug("save started. accountID:" + accountId);
         if (!this.file.getParentFile().exists() && !this.file.getParentFile().mkdirs()) {
             String message = "unable create directory: " + this.file.getParentFile().getAbsolutePath();
             throw PersoniumCoreException.Server.FILE_SYSTEM_ERROR.params(message);
@@ -162,6 +165,7 @@ public class AuthHistoryLastFile {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        log.debug("save ended.");
     }
 
     /**

--- a/src/main/java/io/personium/core/model/impl/fs/CellKeys.java
+++ b/src/main/java/io/personium/core/model/impl/fs/CellKeys.java
@@ -23,12 +23,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.personium.core.PersoniumCoreException;
 
 /**
  * Class that manages cell specific key information.
  */
 public class CellKeys {
+    /** Logger. */
+    private static Logger log = LoggerFactory.getLogger(CellKeys.class);
 
     /** Keys file storage directory name. */
     public static final String KEYS_DIR_NAME = ".pkeys";
@@ -57,12 +62,14 @@ public class CellKeys {
      * @return CellKeys
      */
     public CellKeys load() {
+        log.debug("load started.");
         if (exists()) {
             doLoad();
         } else {
             // Automatically generated if keys file does not exist.
             doCreate();
         }
+        log.debug("load ended.");
         return this;
     }
 

--- a/src/main/java/io/personium/core/model/impl/fs/DavMetadataFile.java
+++ b/src/main/java/io/personium/core/model/impl/fs/DavMetadataFile.java
@@ -162,6 +162,7 @@ public class DavMetadataFile {
      * load from the file.
      */
     public void load() {
+        log.debug("load started.");
         // Coping with core issue #28.
         // When an Exception occurs Retry several times.
         int retryCount = 0;
@@ -185,6 +186,7 @@ public class DavMetadataFile {
                 }
             }
         }
+        log.debug("load ended.");
     }
 
     /**
@@ -204,6 +206,7 @@ public class DavMetadataFile {
      * save to the file.
      */
     public void save() {
+        log.debug("save started.");
         this.incrementVersion();
         String jsonStr = JSONObject.toJSONString(this.getJSON());
         try {
@@ -211,6 +214,7 @@ public class DavMetadataFile {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        log.debug("save ended.");
     }
 
     private void incrementVersion() {

--- a/src/main/java/io/personium/core/rule/RuleManager.java
+++ b/src/main/java/io/personium/core/rule/RuleManager.java
@@ -462,9 +462,11 @@ public class RuleManager {
      * Load rules from DB (Only cells with "timer event").
      */
     private void loadRulesForInitialize() {
+        logger.debug("  loadRulesForInitialize.");
         // Load Rule for cells with timer events.
         // (Other cells read the rule later.)
         List<String> cellIdList = this.searchCellsWithTimerEventOnly();
+        logger.debug("  count cells with TimerEvent:" + cellIdList.size());
         for (String cellId : cellIdList) {
             Cell cell = ModelFactory.cellFromId(cellId);
             synchronized (lockObj) {

--- a/src/test/java/io/personium/test/setup/Setup.java
+++ b/src/test/java/io/personium/test/setup/Setup.java
@@ -147,7 +147,7 @@ public class Setup extends AbstractCase {
 
     static final String TEST_RULE_NAME = "rule1";
     static final long WAIT_TIME_FOR_EVENT = 3000; // msec
-    static final long WAIT_TIME_FOR_BULK_DELETE = 10000L;
+    static final long WAIT_TIME_FOR_BULK_DELETE = 1000L;
 
     /**
      * コンストラクタ. テスト対象のパッケージをsuperに渡す必要がある

--- a/src/test/java/io/personium/test/setup/Setup.java
+++ b/src/test/java/io/personium/test/setup/Setup.java
@@ -147,7 +147,7 @@ public class Setup extends AbstractCase {
 
     static final String TEST_RULE_NAME = "rule1";
     static final long WAIT_TIME_FOR_EVENT = 3000; // msec
-    static final long WAIT_TIME_FOR_BULK_DELETE = 1000L;
+    static final long WAIT_TIME_FOR_BULK_DELETE = 10000L;
 
     /**
      * コンストラクタ. テスト対象のパッケージをsuperに渡す必要がある


### PR DESCRIPTION
Change the timing of loading rules for cells without timer events.
It was read at the first reference, not at startup.

Add debug logs to some of the file operation related parts.
(Not directly related but added for future verification)