### PR TITLE
Support double colons syntax for "personium-localunit" URL scheme

### DIFF
--- a/src/main/java/io/personium/core/PersoniumCoreException.java
+++ b/src/main/java/io/personium/core/PersoniumCoreException.java
@@ -1014,6 +1014,13 @@ public class PersoniumCoreException extends RuntimeException {
          * {0} : Overview of failed processing
          */
         public static final PersoniumCoreException FILE_IO_ERROR = create("PR500-CM-0002");
+
+        /**
+         * Unchecked Invalid URL used internally.
+         * <p>
+         * {0} : URL
+         */
+        public static final PersoniumCoreException INVALID_URL = create("PR500-CM-0003");
     }
 
     /**

--- a/src/main/java/io/personium/core/PersoniumUnitConfig.java
+++ b/src/main/java/io/personium/core/PersoniumUnitConfig.java
@@ -537,14 +537,14 @@ public class PersoniumUnitConfig {
         }
     }
 
-    private static boolean isSpaceSeparatedValueIncluded(String spaceSeparatedValue, String testValue, String unitUrl) {
+    private static boolean isSpaceSeparatedValueIncluded(String spaceSeparatedValue, String testValue) {
         if (testValue == null || spaceSeparatedValue == null) {
             return false;
         }
         String[] values = spaceSeparatedValue.split(" ");
         for (String val : values) {
             // Correspondence when "localunit" is set for issuers.
-            String convertedValue = UriUtils.convertSchemeFromLocalUnitToHttp(unitUrl, val);
+            String convertedValue = UriUtils.convertSchemeFromLocalUnitToHttp(val);
             if (testValue.equals(convertedValue)) {
                 return true;
             }
@@ -1613,8 +1613,8 @@ public class PersoniumUnitConfig {
      * @param unitUrl Unit URL
      * @return Included:true
      */
-    public static boolean checkUnitUserIssuers(String url, String unitUrl) {
-        return isSpaceSeparatedValueIncluded(getUnitUserIssuers(), url, unitUrl);
+    public static boolean checkUnitUserIssuers(String url) {
+        return isSpaceSeparatedValueIncluded(getUnitUserIssuers(), url);
     }
 
     /**

--- a/src/main/java/io/personium/core/auth/AccessContext.java
+++ b/src/main/java/io/personium/core/auth/AccessContext.java
@@ -532,7 +532,7 @@ public class AccessContext {
      */
     public void checkSchemaMatches(Box box) {
         if (box != null) {
-            String boxSchema = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), box.getSchema());
+            String boxSchema = UriUtils.convertSchemeFromLocalUnitToHttp(box.getSchema());
             String tokenSchema = getSchema();
 
             // Do not check if box schema is not set.
@@ -887,8 +887,8 @@ public class AccessContext {
 
         String issuer = tca.getIssuer();
         if ((tca.getTarget().equals(baseUri) || tca.getTarget().equals(escapedBaseUri))
-                && (PersoniumUnitConfig.checkUnitUserIssuers(issuer, baseUri)
-                        || PersoniumUnitConfig.checkUnitUserIssuers(issuer, escapedBaseUri))) {
+                && (PersoniumUnitConfig.checkUnitUserIssuers(issuer)
+                        || PersoniumUnitConfig.checkUnitUserIssuers(issuer))) {
             //Processing unit user tokens
             ret.accessType = TYPE_UNIT_USER;
             ret.subject = tca.getSubject();

--- a/src/main/java/io/personium/core/auth/AccessContext.java
+++ b/src/main/java/io/personium/core/auth/AccessContext.java
@@ -396,7 +396,7 @@ public class AccessContext {
                 || TYPE_UNIT_ADMIN.equals(type)) {
             return true;
         } else if ((TYPE_UNIT_USER.equals(type) || TYPE_UNIT_LOCAL.equals(type))
-                && getSubject().equals(getCell().getOwner())) {
+                && getSubject().equals(getCell().getOwnerNormalized())) {
             //↑ Unit user, Unit For local unit users, this is valid only when the unit owner name included in the token and the cell owner to be processed match.
             return true;
         }
@@ -414,7 +414,7 @@ public class AccessContext {
             return true;
         } else if (TYPE_UNIT_ADMIN.equals(type)
                 || ((TYPE_UNIT_USER.equals(type) || TYPE_UNIT_LOCAL.equals(type)) //NOPMD - To maintain readability
-                        && getSubject().equals(getCell().getOwner()))) {
+                        && getSubject().equals(getCell().getOwnerNormalized()))) {
             // In the case of a UnitUser or UnitLocal, it is effective only when the unit owner name included
             // in the processing target cell owner and the token matches.
 

--- a/src/main/java/io/personium/core/auth/AccessContext.java
+++ b/src/main/java/io/personium/core/auth/AccessContext.java
@@ -896,12 +896,12 @@ public class AccessContext {
 
             //Take role information and if you have unit admin roll, promote to unit admin.
             List<Role> roles = tca.getRoles();
-            Role unitAdminRole = new Role(ROLE_UNIT_ADMIN, Box.DEFAULT_BOX_NAME, null, tca.getIssuer());
+            Role unitAdminRole = new Role(ROLE_UNIT_ADMIN, Box.MAIN_BOX_NAME, null, tca.getIssuer());
             String unitAdminRoleUrl = unitAdminRole.createUrl();
-            Role cellContentsReaderRole = new Role(ROLE_CELL_CONTENTS_READER, Box.DEFAULT_BOX_NAME,
+            Role cellContentsReaderRole = new Role(ROLE_CELL_CONTENTS_READER, Box.MAIN_BOX_NAME,
                     null, tca.getIssuer());
             String cellContentsReaderUrl = cellContentsReaderRole.createUrl();
-            Role cellContentsAdminRole = new Role(ROLE_CELL_CONTENTS_ADMIN, Box.DEFAULT_BOX_NAME,
+            Role cellContentsAdminRole = new Role(ROLE_CELL_CONTENTS_ADMIN, Box.MAIN_BOX_NAME,
                     null, tca.getIssuer());
             String cellContentsAdminUrl = cellContentsAdminRole.createUrl();
 

--- a/src/main/java/io/personium/core/bar/BarFileInstaller.java
+++ b/src/main/java/io/personium/core/bar/BarFileInstaller.java
@@ -311,7 +311,7 @@ public class BarFileInstaller {
     private File storeTemporaryBarFile(InputStream inStream) {
 
         //If there is no directory to store the bar file, it creates it.
-        String unitUserName = BarFileUtils.getUnitUserName(this.cell.getOwner());
+        String unitUserName = BarFileUtils.getUnitUserName(this.cell.getOwnerNormalized());
         File barFileDir = new File(new File(barTempDir, unitUserName), "bar");
         if (!barFileDir.exists() && !barFileDir.mkdirs()) {
             String message = "unable create directory: " + barFileDir.getAbsolutePath();

--- a/src/main/java/io/personium/core/eventlog/ArchiveLogCollection.java
+++ b/src/main/java/io/personium/core/eventlog/ArchiveLogCollection.java
@@ -70,7 +70,7 @@ public class ArchiveLogCollection {
         urlSb.append(uriInfo.getPath());
         this.url = urlSb.toString();
 
-        StringBuilder archiveDirName = EventUtils.getEventLogDir(cell.getId(), cell.getOwner()).append("archive");
+        StringBuilder archiveDirName = EventUtils.getEventLogDir(cell.getId(), cell.getOwnerNormalized()).append("archive");
         this.directoryPath = archiveDirName.toString();
     }
 

--- a/src/main/java/io/personium/core/model/Box.java
+++ b/src/main/java/io/personium/core/model/Box.java
@@ -93,7 +93,7 @@ public class Box {
     /**
      * main box name.
      */
-    public static final String DEFAULT_BOX_NAME = "__";
+    public static final String MAIN_BOX_NAME = "__";
 
     /**
      * Constructor.
@@ -104,7 +104,7 @@ public class Box {
         this.cell = cell;
         if (entity == null) {
             // Process for the MAIN BOX
-            this.name = Box.DEFAULT_BOX_NAME;
+            this.name = Box.MAIN_BOX_NAME;
             // Schema URL of MAIN BOX is the URL of its own cell
             this.schema = cell.getUrl();
             // Internal ID of MAIN BOX will be together with the ID of the cell.

--- a/src/main/java/io/personium/core/model/Cell.java
+++ b/src/main/java/io/personium/core/model/Cell.java
@@ -104,11 +104,16 @@ public interface Cell {
     String getUnitUrl();
 
     /**
-     * It gets the URI of the Cell of the Owner Unit User.
-     * @return Cell name
+     * Returns the normalized URI of the owner Unit User of this Cell.
+     * @return normalized owner url.
      */
-    String getOwner();
+    String getOwnerNormalized();
 
+    /**
+     * Returns the raw URI of the owner Unit User of this Cell.
+     * @return raw owner url.
+     */
+    String getOwnerRaw();
     /**
      * It gets the prefix without Unit User name of the Cell.
      * @return .
@@ -209,4 +214,6 @@ public interface Cell {
      * @return internal id of the given role
      */
     String roleResourceUrlToId(String roleUrl, String baseUrl);
+
+
 }

--- a/src/main/java/io/personium/core/model/CellRsCmp.java
+++ b/src/main/java/io/personium/core/model/CellRsCmp.java
@@ -217,7 +217,7 @@ public class CellRsCmp extends DavRsCmp {
         }
 
         // Convert personium-localunit and personium-localcell.
-        relayHtmlUrl = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), relayHtmlUrl);
+        relayHtmlUrl = UriUtils.convertSchemeFromLocalUnitToHttp(relayHtmlUrl);
         relayHtmlUrl = UriUtils.convertSchemeFromLocalCellToHttp(cell.getUrl(), relayHtmlUrl);
 
         // Validate relayHtmlUrl.
@@ -245,7 +245,7 @@ public class CellRsCmp extends DavRsCmp {
         }
 
         // Convert personium-localunit and personium-localcell.
-        authorizationHtmlUrl = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), authorizationHtmlUrl);
+        authorizationHtmlUrl = UriUtils.convertSchemeFromLocalUnitToHttp(authorizationHtmlUrl);
         authorizationHtmlUrl = UriUtils.convertSchemeFromLocalCellToHttp(cell.getUrl(), authorizationHtmlUrl);
 
         // Validate relayHtmlUrl.
@@ -274,8 +274,7 @@ public class CellRsCmp extends DavRsCmp {
         }
 
         // Convert personium-localunit and personium-localcell.
-        authorizationPasswordHtmlUrl = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(),
-                authorizationPasswordHtmlUrl);
+        authorizationPasswordHtmlUrl = UriUtils.convertSchemeFromLocalUnitToHttp(authorizationPasswordHtmlUrl);
         authorizationPasswordHtmlUrl = UriUtils.convertSchemeFromLocalCellToHttp(cell.getUrl(),
                 authorizationPasswordHtmlUrl);
 

--- a/src/main/java/io/personium/core/model/ModelFactory.java
+++ b/src/main/java/io/personium/core/model/ModelFactory.java
@@ -26,7 +26,6 @@ import io.personium.core.model.impl.es.odata.UserSchemaODataProducer;
 import io.personium.core.model.impl.fs.BoxCmpFsImpl;
 import io.personium.core.model.impl.fs.CellCmpFsImpl;
 import io.personium.core.model.impl.fs.CellSnapshotCellCmpFsImpl;
-import io.personium.core.odata.PersoniumODataProducer;
 
 /**
  * Factory class of model object.
@@ -105,20 +104,20 @@ public final class ModelFactory {
      */
     public static class ODataCtl {
         /**
-         * Returns the ODataProducer handling the Unit management entity.
+         * Returns the ODataProducer handling the Unit control objects.
          * @param ac access context
-         * @return Unit ODataProducer handling management entities
+         * @return UnitCtlODataProducer
          */
-        public static PersoniumODataProducer unitCtl(AccessContext ac) {
+        public static UnitCtlODataProducer unitCtl(AccessContext ac) {
             return new UnitCtlODataProducer(ac);
         }
 
         /**
-         * Returns the ODataProducer handling the Cell management entity.
+         * Returns the ODataProducer handling the Cell control objects.
          * @param cell Cell's Cell
-         * @return ODataProducer handling Cell management entities
+         * @return CellCtlODataProducer
          */
-        public static PersoniumODataProducer cellCtl(final Cell cell) {
+        public static CellCtlODataProducer cellCtl(final Cell cell) {
             return new CellCtlODataProducer(cell);
         }
 
@@ -126,9 +125,9 @@ public final class ModelFactory {
          * Return ODataProducer for producing OData about message.
          * @param cell target cell object
          * @param davRsCmp DavRsCmp
-         * @return PersoniumODataProducer MessageODataProducer
+         * @return MessageODataProducer MessageODataProducer
          */
-        public static PersoniumODataProducer message(final Cell cell, final DavRsCmp davRsCmp) {
+        public static MessageODataProducer message(final Cell cell, final DavRsCmp davRsCmp) {
             return new MessageODataProducer(cell, davRsCmp);
         }
 
@@ -136,9 +135,9 @@ public final class ModelFactory {
          * Return ODataProducer of user data schema.
          * @param cell Cell
          * @param davCmp DavCmp
-         * @return ODataProducer
+         * @return UserSchemaODataProducer
          */
-        public static PersoniumODataProducer userSchema(final Cell cell, final DavCmp davCmp) {
+        public static UserSchemaODataProducer userSchema(final Cell cell, final DavCmp davCmp) {
             return new UserSchemaODataProducer(cell, davCmp);
         }
 
@@ -146,9 +145,9 @@ public final class ModelFactory {
          * Return ODataProducer of user data.
          * @param cell Cell
          * @param davCmp DavCmp
-         * @return ODataProducer
+         * @return UserDataODataProducer
          */
-        public static PersoniumODataProducer userData(final Cell cell, final DavCmp davCmp) {
+        public static UserDataODataProducer userData(final Cell cell, final DavCmp davCmp) {
             return new UserDataODataProducer(cell, davCmp);
         }
 

--- a/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
@@ -329,7 +329,7 @@ public class CellEsImpl implements Cell {
         }
 
         // check that Main Box is empty
-        Box defaultBox = this.getBoxForName(Box.DEFAULT_BOX_NAME);
+        Box defaultBox = this.getBoxForName(Box.MAIN_BOX_NAME);
         BoxCmp defaultBoxCmp = ModelFactory.boxCmp(defaultBox);
         if (!defaultBoxCmp.isEmpty()) {
             return false;
@@ -433,7 +433,7 @@ public class CellEsImpl implements Cell {
 
     @Override
     public Box getBoxForName(String boxName) {
-        if (Box.DEFAULT_BOX_NAME.equals(boxName)) {
+        if (Box.MAIN_BOX_NAME.equals(boxName)) {
             return new Box(this, null);
         }
 
@@ -668,7 +668,7 @@ public class CellEsImpl implements Cell {
         Map<String, Object> query = QueryMapFactory.filteredQuery(null, QueryMapFactory.mustQuery(queries));
 
         List<Map<String, Object>> filters = new ArrayList<Map<String, Object>>();
-        if (!(Box.DEFAULT_BOX_NAME.equals(role.getBoxName()))) {
+        if (!(Box.MAIN_BOX_NAME.equals(role.getBoxName()))) {
             //Add search queries when Role is tied to a box
             Box targetBox = this.getBoxForName(role.getBoxName());
             if (targetBox == null) {

--- a/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
@@ -656,7 +656,7 @@ public class CellEsImpl implements Cell {
         }
 
         //It is not permitted to designate the cell URL portion of the role resource different from the cell URL of the ACL setting target
-        if (!(this.getUrl().equals(role.getBaseUrl()))) {
+        if (!UriUtils.equalIgnoringPort(this.getUrl(), role.getBaseUrl())) {
             PersoniumCoreLog.Dav.ROLE_NOT_FOUND.params("Cell different").writeLog();
             throw PersoniumCoreException.Dav.ROLE_NOT_FOUND;
         }

--- a/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
@@ -136,7 +136,6 @@ public class CellEsImpl implements Cell {
         CellEsImpl cell = (CellEsImpl) findCell("s.Name.untouched", cellName);
         if (cell != null) {
             cell.url = PersoniumUnitConfig.getBaseUrl() + cell.name + "/";
-            cell.owner = UriUtils.convertSchemeFromLocalUnitToHttp(cell.owner);
         }
         return cell;
     }
@@ -262,7 +261,7 @@ public class CellEsImpl implements Cell {
             return UriUtils.convertPathBaseToFqdnBase(url);
         } catch (URISyntaxException e) {
             // Usually it does not occur.
-            throw PersoniumCoreException.Server.UNKNOWN_ERROR;
+            throw PersoniumCoreException.Server.UNKNOWN_ERROR.reason(e);
         }
     }
 
@@ -284,9 +283,14 @@ public class CellEsImpl implements Cell {
     }
 
     @Override
-    public String getOwner() {
+    public String getOwnerNormalized() {
+        return UriUtils.convertSchemeFromLocalUnitToHttp(this.owner);
+    }
+    @Override
+    public String getOwnerRaw() {
         return this.owner;
     }
+
 
     @Override
     public String getDataBundleNameWithOutPrefix() {
@@ -374,7 +378,7 @@ public class CellEsImpl implements Cell {
 
         // Delete event log file.
         try {
-            EventUtils.deleteEventLog(this.getId(), this.getOwner());
+            EventUtils.deleteEventLog(this.getId(), this.getOwnerNormalized());
         } catch (BinaryDataAccessException e) {
             // If the deletion fails, output a log and continue processing.
             log.warn("Delete EventLog Failed." + cellInfoLog, e);

--- a/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/es/CellEsImpl.java
@@ -136,7 +136,7 @@ public class CellEsImpl implements Cell {
         CellEsImpl cell = (CellEsImpl) findCell("s.Name.untouched", cellName);
         if (cell != null) {
             cell.url = PersoniumUnitConfig.getBaseUrl() + cell.name + "/";
-            cell.owner = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), cell.owner);
+            cell.owner = UriUtils.convertSchemeFromLocalUnitToHttp(cell.owner);
         }
         return cell;
     }
@@ -466,7 +466,7 @@ public class CellEsImpl implements Cell {
     @Override
     public Box getBoxForSchema(String boxSchema) {
         //Retrieving the schema name list (including aliases)
-        List<String> boxSchemas = UriUtils.getUrlVariations(this.getUnitUrl(), boxSchema);
+        List<String> boxSchemas = UriUtils.getUrlVariations(boxSchema);
 
         ODataProducer op = ModelFactory.ODataCtl.cellCtl(this);
         for (int i = 0; i < boxSchemas.size(); i++) {
@@ -773,7 +773,7 @@ public class CellEsImpl implements Cell {
             //Number of search result output setting
             QueryInfo qi = QueryInfo.newBuilder().setTop(TOP_NUM).setInlineCount(InlineCount.NONE).build();
 
-            List<String> list = UriUtils.getUrlVariations(this.getUnitUrl(), extCell);
+            List<String> list = UriUtils.getUrlVariations(extCell);
             for (int i = 0; i < list.size(); i++) {
                 String extCellUrl = list.get(i);
                 try {
@@ -822,7 +822,7 @@ public class CellEsImpl implements Cell {
         EntitiesResponse response = null;
         //Number of search result output setting
         QueryInfo qi = QueryInfo.newBuilder().setTop(TOP_NUM).setInlineCount(InlineCount.NONE).build();
-        List<String> list = UriUtils.getUrlVariations(this.getUnitUrl(), extCell);
+        List<String> list = UriUtils.getUrlVariations(extCell);
         for (int i = 0; i < list.size(); i++) {
             try {
                 String extCellUrl = list.get(i);

--- a/src/main/java/io/personium/core/model/impl/es/EsModel.java
+++ b/src/main/java/io/personium/core/model/impl/es/EsModel.java
@@ -203,7 +203,7 @@ public class EsModel {
     }
 
     static EntitySetAccessor cell(final Cell cell, final String type) {
-        String userUri = cell.getOwner();
+        String userUri = cell.getOwnerNormalized();
         return new ODataEntityAccessor(idxUser(userUri), type, cell.getId());
     }
 
@@ -222,7 +222,7 @@ public class EsModel {
      * @return Type object
      */
     public static ODataLinkAccessor cellCtlLink(final Cell cell) {
-        String userUri = cell.getOwner();
+        String userUri = cell.getOwnerNormalized();
         return new ODataLinkAccessor(idxUser(userUri), TYPE_CTL_LINK, cell.getId());
     }
 
@@ -245,7 +245,7 @@ public class EsModel {
      * @return BulkDataAccessor
      */
     public static DataSourceAccessor batch(final Cell cell) {
-        return new DataSourceAccessor(idxUser(cell.getOwner()));
+        return new DataSourceAccessor(idxUser(cell.getOwnerNormalized()));
     }
 
     /**

--- a/src/main/java/io/personium/core/model/impl/es/odata/MessageODataProducer.java
+++ b/src/main/java/io/personium/core/model/impl/es/odata/MessageODataProducer.java
@@ -316,9 +316,9 @@ public class MessageODataProducer extends CellCtlODataProducer {
         if (extCellDocHandler == null) {
             String convertedTargetUrl;
             if (UriUtils.isLocalUnitUrl(targetUrl)) {
-                convertedTargetUrl = UriUtils.convertSchemeFromLocalUnitToHttp(this.cell.getUnitUrl(), targetUrl);
+                convertedTargetUrl = UriUtils.convertSchemeFromLocalUnitToHttp(targetUrl);
             } else {
-                convertedTargetUrl = UriUtils.convertSchemeFromHttpToLocalUnit(this.cell.getUnitUrl(), targetUrl);
+                convertedTargetUrl = UriUtils.convertSchemeFromHttpToLocalUnit(targetUrl);
             }
             Map<String, Object> convertedExtCellKeyMap = new HashMap<>();
             convertedExtCellKeyMap.put(Common.P_URL.getName(), convertedTargetUrl);
@@ -470,9 +470,9 @@ public class MessageODataProducer extends CellCtlODataProducer {
         if (extCellDocHandler == null) {
             String convertedTargetUrl;
             if (UriUtils.isLocalUnitUrl(targetUrl)) {
-                convertedTargetUrl = UriUtils.convertSchemeFromLocalUnitToHttp(this.cell.getUnitUrl(), targetUrl);
+                convertedTargetUrl = UriUtils.convertSchemeFromLocalUnitToHttp(targetUrl);
             } else {
-                convertedTargetUrl = UriUtils.convertSchemeFromHttpToLocalUnit(this.cell.getUnitUrl(), targetUrl);
+                convertedTargetUrl = UriUtils.convertSchemeFromHttpToLocalUnit(targetUrl);
             }
             Map<String, Object> convertedExtCellKeyMap = new HashMap<>();
             convertedExtCellKeyMap.put(Common.P_URL.getName(), convertedTargetUrl);
@@ -694,7 +694,7 @@ public class MessageODataProducer extends CellCtlODataProducer {
         log.debug(String.format("ClassUrl = [%s]", classUrl));
 
         // convert localunitUrl to unitUrl
-        String convertedRequestRelation = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), classUrl);
+        String convertedRequestRelation = UriUtils.convertSchemeFromLocalUnitToHttp(classUrl);
         Pattern pattern = Pattern.compile(regex);
         Matcher m = pattern.matcher(convertedRequestRelation);
         if (m.matches()) {
@@ -718,7 +718,7 @@ public class MessageODataProducer extends CellCtlODataProducer {
         log.debug(String.format("RequestRelation = [%s]", classUrl));
 
         // convert localunitUrl to unitUrl
-        String convertedRequestRelation = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), classUrl);
+        String convertedRequestRelation = UriUtils.convertSchemeFromLocalUnitToHttp(classUrl);
         Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(convertedRequestRelation);
         if (matcher.matches()) {

--- a/src/main/java/io/personium/core/model/impl/es/odata/UnitCtlODataProducer.java
+++ b/src/main/java/io/personium/core/model/impl/es/odata/UnitCtlODataProducer.java
@@ -76,8 +76,7 @@ public class UnitCtlODataProducer extends EsODataProducer {
         if (AccessContext.TYPE_UNIT_USER.equals(this.accesscontext.getType())
                 || AccessContext.TYPE_UNIT_LOCAL.equals(this.accesscontext.getType())) {
             // Search for matching owner in http format or localunit format.
-            String localOwner = UriUtils.convertSchemeFromHttpToLocalUnit(
-                    accesscontext.getBaseUri(), accesscontext.getSubject());
+            String localOwner = UriUtils.convertSchemeFromHttpToLocalUnit(accesscontext.getSubject());
             List<Map<String, Object>> orQueries = new ArrayList<Map<String, Object>>();
             orQueries.add(QueryMapFactory.termQuery(OEntityDocHandler.KEY_OWNER, accesscontext.getSubject()));
             orQueries.add(QueryMapFactory.termQuery(OEntityDocHandler.KEY_OWNER, localOwner));

--- a/src/main/java/io/personium/core/model/impl/fs/DavCmpFsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/fs/DavCmpFsImpl.java
@@ -1153,7 +1153,7 @@ public class DavCmpFsImpl implements DavCmp {
             //In case of Cell level ACL, the resource URL of default box
             //Since cell URLs are attached with slashes in concatenation, erase the URL if it ends with a slash.
             result = String.format(Role.ROLE_RESOURCE_FORMAT, this.cell.getUrl().replaceFirst("/$", ""),
-                    Box.DEFAULT_BOX_NAME, "");
+                    Box.MAIN_BOX_NAME, "");
         }
         return result;
     }

--- a/src/main/java/io/personium/core/model/impl/fs/DavCmpFsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/fs/DavCmpFsImpl.java
@@ -1033,7 +1033,7 @@ public class DavCmpFsImpl implements DavCmp {
      * @return instance of accessor
      */
     protected BinaryDataAccessor getBinaryDataAccessor() {
-        String owner = cell.getOwner();
+        String owner = cell.getOwnerNormalized();
         String unitUserName = null;
         if (owner == null) {
             unitUserName = AccessContext.TYPE_ANONYMOUS;

--- a/src/main/java/io/personium/core/model/jaxb/Acl.java
+++ b/src/main/java/io/personium/core/model/jaxb/Acl.java
@@ -43,6 +43,7 @@ import io.personium.core.auth.BoxPrivilege;
 import io.personium.core.auth.CellPrivilege;
 import io.personium.core.auth.OAuth2Helper;
 import io.personium.core.auth.Privilege;
+import io.personium.core.utils.UriUtils;
 
 /**
  * A model object representing an ACL.
@@ -93,7 +94,7 @@ public final class Acl {
      * @param base baseUrl
      */
     public void setBase(String base) {
-        this.base = base;
+        this.base = UriUtils.convertSchemeFromHttpToLocalUnit(base);
     }
 
     /**
@@ -101,7 +102,7 @@ public final class Acl {
      * @return base
      */
     public String getBase() {
-        return base;
+        return UriUtils.convertSchemeFromLocalUnitToHttp(base);
     }
 
     /**

--- a/src/main/java/io/personium/core/rs/box/BoxResource.java
+++ b/src/main/java/io/personium/core/rs/box/BoxResource.java
@@ -443,7 +443,7 @@ public class BoxResource {
             //TODO findBugs countermeasure ↓
             log.debug(requestKey);
 
-            if (Box.DEFAULT_BOX_NAME.equals(this.boxName)) {
+            if (Box.MAIN_BOX_NAME.equals(this.boxName)) {
                 throw PersoniumCoreException.Misc.METHOD_NOT_ALLOWED;
             }
 

--- a/src/main/java/io/personium/core/rs/box/StreamResource.java
+++ b/src/main/java/io/personium/core/rs/box/StreamResource.java
@@ -16,9 +16,9 @@
  */
 package io.personium.core.rs.box;
 
-import java.net.URI;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -187,8 +187,7 @@ public abstract class StreamResource {
      */
     private String createDestination(String name) {
         // convert to localunit url
-        String localunit = UriUtils.convertSchemeFromHttpToLocalUnit(this.davRsCmp.getCell().getUnitUrl(),
-                                                                     getUrl(name));
+        String localunit = UriUtils.convertSchemeFromHttpToLocalUnit(getUrl(name));
         try {
             URI uri = new URI(localunit);
             return Stream.of(uri.getPath().split(Pattern.quote("/")))

--- a/src/main/java/io/personium/core/rs/cell/AuthzEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/AuthzEndPointResource.java
@@ -1012,9 +1012,9 @@ public class AuthzEndPointResource {
             //title
             paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
             //Ansel's profile.json
-            paramsList.add(clientId + Box.DEFAULT_BOX_NAME + PROFILE_JSON_NAME);
+            paramsList.add(clientId + Box.MAIN_BOX_NAME + PROFILE_JSON_NAME);
             //Data cell profile.json
-            paramsList.add(cell.getUrl() + Box.DEFAULT_BOX_NAME + PROFILE_JSON_NAME);
+            paramsList.add(cell.getUrl() + Box.MAIN_BOX_NAME + PROFILE_JSON_NAME);
             //title
             paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
             //Callee
@@ -1084,9 +1084,9 @@ public class AuthzEndPointResource {
             //title
             paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
             //Ansel's profile.json
-            paramsList.add(clientId + Box.DEFAULT_BOX_NAME + PROFILE_JSON_NAME);
+            paramsList.add(clientId + Box.MAIN_BOX_NAME + PROFILE_JSON_NAME);
             //Data cell profile.json
-            paramsList.add(cell.getUrl() + Box.DEFAULT_BOX_NAME + PROFILE_JSON_NAME);
+            paramsList.add(cell.getUrl() + Box.MAIN_BOX_NAME + PROFILE_JSON_NAME);
             //title
             paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
             //Callee

--- a/src/main/java/io/personium/core/rs/cell/BoxUrlResource.java
+++ b/src/main/java/io/personium/core/rs/cell/BoxUrlResource.java
@@ -36,6 +36,7 @@ import io.personium.core.model.DavCmp;
 import io.personium.core.model.DavRsCmp;
 import io.personium.core.model.ModelFactory;
 import io.personium.core.utils.ODataUtils;
+import io.personium.core.utils.UriUtils;
 
 /**
  * JOX-RS Resource for obtaining Box URL.
@@ -86,6 +87,7 @@ public class BoxUrlResource {
         if (schema == null || schema.length() == 0) {
             box = this.cellRsCmp.getBox();
         } else {
+            schema = UriUtils.resolveLocalUnit(schema);
             //Acquire Box from schema information
             box = this.cellRsCmp.getCell().getBoxForSchema(schema);
         }

--- a/src/main/java/io/personium/core/rs/cell/BoxUrlResource.java
+++ b/src/main/java/io/personium/core/rs/cell/BoxUrlResource.java
@@ -36,7 +36,6 @@ import io.personium.core.model.DavCmp;
 import io.personium.core.model.DavRsCmp;
 import io.personium.core.model.ModelFactory;
 import io.personium.core.utils.ODataUtils;
-import io.personium.core.utils.UriUtils;
 
 /**
  * JOX-RS Resource for obtaining Box URL.
@@ -87,7 +86,6 @@ public class BoxUrlResource {
         if (schema == null || schema.length() == 0) {
             box = this.cellRsCmp.getBox();
         } else {
-            schema = UriUtils.resolveLocalUnit(schema);
             //Acquire Box from schema information
             box = this.cellRsCmp.getCell().getBoxForSchema(schema);
         }

--- a/src/main/java/io/personium/core/rs/cell/CellCtlResource.java
+++ b/src/main/java/io/personium/core/rs/cell/CellCtlResource.java
@@ -29,7 +29,6 @@ import org.odata4j.core.OEntityKey;
 import org.odata4j.core.OProperty;
 
 import io.personium.core.PersoniumCoreException;
-import io.personium.core.PersoniumUnitConfig;
 import io.personium.core.auth.AccessContext;
 import io.personium.core.auth.AuthUtils;
 import io.personium.core.auth.CellPrivilege;
@@ -285,8 +284,7 @@ public final class CellCtlResource extends ODataResource {
                 }
             }
 
-            String error = validateRule(PersoniumUnitConfig.getBaseUrl(),
-                    external, subject, type, object, info, action, targetUrl, boxBound);
+            String error = validateRule(external, subject, type, object, info, action, targetUrl, boxBound);
             if (error != null) {
                 throw PersoniumCoreException.OData.REQUEST_FIELD_FORMAT_ERROR.params(error);
             }
@@ -306,16 +304,15 @@ public final class CellCtlResource extends ODataResource {
      * @param boxBound flag of box bounded
      * @return property name of format error
      */
-    public static String validateRule(String unitUrl,
-            Boolean external, String subject,
+    public static String validateRule(Boolean external, String subject,
             String type, String object, String info, String action, String targetUrl, Boolean boxBound) {
 
         // check if convert scheme to localunit
-        String converted = UriUtils.convertSchemeFromHttpToLocalUnit(unitUrl, subject);
+        String converted = UriUtils.convertSchemeFromHttpToLocalUnit(subject);
         if (converted != null && !converted.equals(subject)) {
             return Rule.P_SUBJECT.getName();
         }
-        converted = UriUtils.convertSchemeFromHttpToLocalUnit(unitUrl, targetUrl);
+        converted = UriUtils.convertSchemeFromHttpToLocalUnit(targetUrl);
         if (converted != null && !converted.equals(targetUrl)) {
             return Rule.P_TARGETURL.getName();
         }

--- a/src/main/java/io/personium/core/rs/cell/CellResource.java
+++ b/src/main/java/io/personium/core/rs/cell/CellResource.java
@@ -385,7 +385,7 @@ public class CellResource {
      */
     @Path("__")
     public BoxResource box(@Context final Request jaxRsRequest) {
-        return new BoxResource(this.cell, Box.DEFAULT_BOX_NAME, this.accessContext,
+        return new BoxResource(this.cell, Box.MAIN_BOX_NAME, this.accessContext,
                 this.cellRsCmp, jaxRsRequest);
     }
 

--- a/src/main/java/io/personium/core/rs/cell/CellResource.java
+++ b/src/main/java/io/personium/core/rs/cell/CellResource.java
@@ -129,7 +129,7 @@ public class CellResource {
     private void checkReferenceMode() {
         Cell cellObj = accessContext.getCell();
         String unitPrefix = PersoniumUnitConfig.getEsUnitPrefix();
-        String owner = cellObj.getOwner();
+        String owner = cellObj.getOwnerNormalized();
 
         if (owner == null) {
             owner = "anon";
@@ -224,7 +224,7 @@ public class CellResource {
         }
         //Confirm the access authority
         //Unit Master, Unit User, Unit Local Unit User except authority error
-        String cellOwner = this.cell.getOwner();
+        String cellOwner = this.cell.getOwnerNormalized();
         checkAccessContextForCellBulkDeletion(cellOwner);
 
         String cellId = this.cell.getId();

--- a/src/main/java/io/personium/core/rs/cell/LogResource.java
+++ b/src/main/java/io/personium/core/rs/cell/LogResource.java
@@ -279,7 +279,7 @@ public class LogResource {
         }
 
         String cellId = davRsCmp.getCell().getId();
-        String owner = davRsCmp.getCell().getOwner();
+        String owner = davRsCmp.getCell().getOwnerNormalized();
 
         //Get the path of the log file
         StringBuilder logFileName = EventUtils.getEventLogDir(cellId, owner);
@@ -383,7 +383,7 @@ public class LogResource {
         }
 
         String cellId = davRsCmp.getCell().getId();
-        String owner = davRsCmp.getCell().getOwner();
+        String owner = davRsCmp.getCell().getOwnerNormalized();
 
         //Delete event log file
         StringBuilder logFilePath = EventUtils.getEventLogDir(cellId, owner);

--- a/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
@@ -409,7 +409,7 @@ public class TokenEndPointResource {
         //Give # c if the role is a confidential value
         String confidentialRoleUrl = String.format(
                 OAuth2Helper.Key.CONFIDENTIAL_ROLE_URL_FORMAT,
-                tcToken.getIssuer(), Box.DEFAULT_BOX_NAME);
+                tcToken.getIssuer(), Box.MAIN_BOX_NAME);
         for (Role role : tcToken.getRoles()) {
             if (confidentialRoleUrl.equals(role.createUrl())) {
                 //Successful authentication.

--- a/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
@@ -155,6 +155,7 @@ public class TokenEndPointResource {
         if (target != null) {
             this.checkURL(target);
             target = this.addTrainlingSlash(target);
+            // TODO should do more normalization.
         }
 
         // Do not issue cookie if p_target exists, regardless of the p_cookie parameter.
@@ -641,13 +642,13 @@ public class TokenEndPointResource {
                 throw PersoniumCoreAuthnException.NOT_ALLOWED_REPRESENT_OWNER.realm(this.cell.getUrl());
             }
             //Do not promote cells for which the owner of the cell is not set.
-            if (cell.getOwner() == null) {
+            if (cell.getOwnerNormalized() == null) {
                 throw PersoniumCoreAuthnException.NO_CELL_OWNER.realm(this.cell.getUrl());
             }
 
             //uluut issuance processing
             UnitLocalUnitUserToken uluut = new UnitLocalUnitUserToken(issuedAt, expiresIn,
-                    cell.getOwner(), cell.getUnitUrl());
+                    cell.getOwnerNormalized(), cell.getUnitUrl());
 
             return this.responseAuthSuccess(uluut, null, issuedAt);
         } else {
@@ -903,13 +904,13 @@ public class TokenEndPointResource {
                         .realm(this.cell.getUrl());
             }
             //Do not promote cells for which the owner of the cell is not set.
-            if (cell.getOwner() == null) {
+            if (cell.getOwnerNormalized() == null) {
                 throw PersoniumCoreAuthnException.NO_CELL_OWNER.realm(this.cell.getUrl());
             }
 
             //uluut issuance processing
             UnitLocalUnitUserToken uluut = new UnitLocalUnitUserToken(issuedAt, expiresIn,
-                    cell.getOwner(), cell.getUnitUrl());
+                    cell.getOwnerNormalized(), cell.getUnitUrl());
             return this.responseAuthSuccess(uluut, null, issuedAt);
         }
 

--- a/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
@@ -152,8 +152,7 @@ public class TokenEndPointResource {
         String pCookie = formParams.getFirst("p_cookie");
 
         // Accept unit local scheme url.
-        String target = UriUtils.convertSchemeFromLocalUnitToHttp(
-                cell.getUnitUrl(), pTarget);
+        String target = UriUtils.convertSchemeFromLocalUnitToHttp(pTarget);
         //If p_target is not a URL, it creates a vulnerability of header injection. (Such as a line feed code is included)
         target = this.checkPTarget(target);
 

--- a/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
@@ -150,6 +150,7 @@ public class TokenEndPointResource {
 
         // relsolve personium-localunit scheme url.
         String target = UriUtils.convertSchemeFromLocalUnitToHttp(pTarget);
+
         //Check the given target to prevent security attacks such as Header Injection.
         //eg. If p_target is not a URL and include line feed code, it creates a vulnerability of header injection.
         if (target != null) {
@@ -369,6 +370,9 @@ public class TokenEndPointResource {
                         .realm(cellUrl);
             }
         }
+
+        // relsolve personium-localunit scheme url.
+        targetClientId = UriUtils.resolveLocalUnit(targetClientId);
 
         //Check pw
         //· Since PW is a SAML token, it is parsed.

--- a/src/main/java/io/personium/core/rs/unit/UnitCtlResource.java
+++ b/src/main/java/io/personium/core/rs/unit/UnitCtlResource.java
@@ -135,7 +135,7 @@ public class UnitCtlResource extends ODataResource {
             // If there is a Subject value in UnitUserToken, set that value to Owner.
             String subject = this.getAccessContext().getSubject();
             if (subject != null) {
-                String owner = UriUtils.convertSchemeFromHttpToLocalUnit(getAccessContext().getBaseUri(), subject);
+                String owner = UriUtils.convertSchemeFromHttpToLocalUnit(subject);
                 oEntityWrapper.put("Owner", owner);
             }
         }
@@ -236,7 +236,7 @@ public class UnitCtlResource extends ODataResource {
     @Override
     public void checkAccessContextPerEntity(AccessContext ac, OEntityWrapper oew) {
         Map<String, Object> meta = oew.getMetadata();
-        String owner = UriUtils.convertSchemeFromLocalUnitToHttp(ac.getBaseUri(), (String) meta.get("Owner"));
+        String owner = UriUtils.convertSchemeFromLocalUnitToHttp((String) meta.get("Owner"));
 
         // In case of master token, no check is required.
         if (AccessContext.TYPE_UNIT_MASTER.equals(ac.getType())

--- a/src/main/java/io/personium/core/rs/unit/UnitCtlResource.java
+++ b/src/main/java/io/personium/core/rs/unit/UnitCtlResource.java
@@ -187,7 +187,7 @@ public class UnitCtlResource extends ODataResource {
     public void afterDelete(final String entitySetName, final OEntityKey oEntityKey) {
         if (Cell.EDM_TYPE_NAME.equals(entitySetName)) {
             //Delete event log if it exists under Cell
-            String owner = cell.getOwner();
+            String owner = cell.getOwnerNormalized();
             try {
                 EventUtils.deleteEventLog(this.cell.getId(), owner);
             } catch (BinaryDataAccessException e) {

--- a/src/main/java/io/personium/core/rs/unit/UnitCtlResource.java
+++ b/src/main/java/io/personium/core/rs/unit/UnitCtlResource.java
@@ -67,7 +67,7 @@ public class UnitCtlResource extends ODataResource {
      * @param accessContext AccessContext
      */
     public UnitCtlResource(AccessContext accessContext) {
-        super(accessContext, UriUtils.SCHEME_UNIT_URI + "__ctl/",
+        super(accessContext, UriUtils.SCHEME_LOCALUNIT + ":/__ctl/",
                 ModelFactory.ODataCtl.unitCtl(accessContext));
         checkReferenceMode(accessContext);
     }

--- a/src/main/java/io/personium/core/rule/RuleManager.java
+++ b/src/main/java/io/personium/core/rule/RuleManager.java
@@ -784,7 +784,7 @@ public class RuleManager {
                 if (bi != null) {
                     bi.name = box.getName();
                     String schema = box.getSchema();
-                    bi.schema = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), schema);
+                    bi.schema = UriUtils.convertSchemeFromLocalUnitToHttp(schema);
                 }
             }
         }
@@ -853,7 +853,7 @@ public class RuleManager {
         RuleInfo rule = createRuleInfo(oEntity);
 
         // Replace personium-localunit scheme to http scheme.
-        rule.subject = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), rule.subject);
+        rule.subject = UriUtils.convertSchemeFromLocalUnitToHttp(rule.subject);
         // Remove fragment from TargetUrl
         rule.targeturl = removeFragment(rule.targeturl);
         try {
@@ -868,7 +868,7 @@ public class RuleManager {
                     list.remove(0);
                     relative = list.stream().collect(Collectors.joining("/"));
                 }
-                String turl = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), rule.targeturl);
+                String turl = UriUtils.convertSchemeFromLocalUnitToHttp(rule.targeturl);
                 if (relative != null) {
                     turl += "#" + relative;
                 }
@@ -904,7 +904,7 @@ public class RuleManager {
                         bi.id = box.getId();
                         bi.name = box.getName();
                         String schema = box.getSchema();
-                        bi.schema = UriUtils.convertSchemeFromLocalUnitToHttp(cell.getUnitUrl(), schema);
+                        bi.schema = UriUtils.convertSchemeFromLocalUnitToHttp(schema);
                         bi.count = 0;
                         bmap.put(bi.id, bi);
                     }

--- a/src/main/java/io/personium/core/rule/action/LogAction.java
+++ b/src/main/java/io/personium/core/rule/action/LogAction.java
@@ -63,7 +63,7 @@ public class LogAction extends Action {
      */
     public LogAction(final Cell cell, LEVEL level) {
         this();
-        String unitUserName = getUnitUserName(Optional.ofNullable(cell.getOwner()));
+        String unitUserName = getUnitUserName(Optional.ofNullable(cell.getOwnerNormalized()));
         String prefix1 = cell.getId().substring(IDX_1ST_START, IDX_1ST_END);
         String prefix2 = cell.getId().substring(IDX_2ND_START, IDX_2ND_END);
         String path = new StringBuilder(unitUserName)

--- a/src/main/java/io/personium/core/snapshot/SnapshotFileImportRunner.java
+++ b/src/main/java/io/personium/core/snapshot/SnapshotFileImportRunner.java
@@ -234,7 +234,7 @@ public class SnapshotFileImportRunner implements Runnable {
         Map<String, Object> s = (Map<String, Object>) map.get(OEntityDocHandler.KEY_STATIC_FIELDS);
         s.put("Name", targetCell.getName());
         Map<String, Object> h = (Map<String, Object>) map.get(OEntityDocHandler.KEY_HIDDEN_FIELDS);
-        String owner = UriUtils.convertSchemeFromHttpToLocalUnit(targetCell.getUnitUrl(), targetCell.getOwner());
+        String owner = UriUtils.convertSchemeFromHttpToLocalUnit(targetCell.getOwner());
         h.put("Owner", owner);
         map.put(OEntityDocHandler.KEY_UPDATED, System.currentTimeMillis());
 

--- a/src/main/java/io/personium/core/snapshot/SnapshotFileImportRunner.java
+++ b/src/main/java/io/personium/core/snapshot/SnapshotFileImportRunner.java
@@ -234,7 +234,7 @@ public class SnapshotFileImportRunner implements Runnable {
         Map<String, Object> s = (Map<String, Object>) map.get(OEntityDocHandler.KEY_STATIC_FIELDS);
         s.put("Name", targetCell.getName());
         Map<String, Object> h = (Map<String, Object>) map.get(OEntityDocHandler.KEY_HIDDEN_FIELDS);
-        String owner = UriUtils.convertSchemeFromHttpToLocalUnit(targetCell.getOwner());
+        String owner = UriUtils.convertSchemeFromHttpToLocalUnit(targetCell.getOwnerNormalized());
         h.put("Owner", owner);
         map.put(OEntityDocHandler.KEY_UPDATED, System.currentTimeMillis());
 

--- a/src/main/java/io/personium/core/utils/ODataUtils.java
+++ b/src/main/java/io/personium/core/utils/ODataUtils.java
@@ -360,17 +360,6 @@ public final class ODataUtils {
         return isValidUrnScheme(scheme) || isValidCellUrlScheme(scheme);
     }
 
-    private static boolean isValidLocalUnitUrlScheme(String scheme) {
-        return UriUtils.SCHEME_LOCALUNIT.equals(scheme);
-    }
-
-    private static boolean isValidLocalCellUrlScheme(String scheme) {
-        return UriUtils.SCHEME_LOCALCELL.equals(scheme);
-    }
-
-    private static boolean isValidLocalBoxUrlScheme(String scheme) {
-        return UriUtils.SCHEME_LOCALBOX.equals(scheme);
-    }
 
     /**
      * Check if string is valid Uri.
@@ -454,8 +443,10 @@ public final class ODataUtils {
         }
         String scheme = uri.getScheme();
         boolean isValidScheme = isValidCellUrlScheme(scheme);
-        if (isValidScheme && isValidLocalUnitUrlScheme(scheme)) {
-            isValidScheme = validateLocalUnitUrl(str, Common.PATTERN_CELL_LOCALUNIT_PATH);
+        if (isValidScheme && UriUtils.SCHEME_LOCALUNIT.equals(scheme)) {
+            boolean b1 = validateLocalUnitUrl(str, Common.PATTERN_CELL_LOCALUNIT_PATH);
+            boolean b2 = UriUtils.REGEX_LOCALUNIT_DOUBLE_COLONS.matcher(str).matches();
+            isValidScheme = b1 || b2;
         }
         boolean isNormalized = uri.normalize().toString().equals(str);
         boolean hasTrailingSlash = str.endsWith("/");
@@ -488,7 +479,7 @@ public final class ODataUtils {
             return false;
         }
         String scheme = uri.getScheme();
-        boolean isValidScheme = isValidLocalCellUrlScheme(scheme);
+        boolean isValidScheme = UriUtils.SCHEME_LOCALCELL.equals(scheme);
         boolean isNormalized = uri.normalize().toString().equals(str);
         return isValidLength && isValidScheme && isNormalized;
     }
@@ -510,7 +501,7 @@ public final class ODataUtils {
             return false;
         }
         String scheme = uri.getScheme();
-        boolean isValidScheme = isValidLocalBoxUrlScheme(scheme);
+        boolean isValidScheme = UriUtils.SCHEME_LOCALBOX.equals(scheme);
         boolean isNormalized = uri.normalize().toString().equals(str);
         return isValidLength && isValidScheme && isNormalized;
     }
@@ -532,7 +523,7 @@ public final class ODataUtils {
             return false;
         }
         String scheme = uri.getScheme();
-        boolean isValidScheme = isValidLocalUnitUrlScheme(scheme);
+        boolean isValidScheme = UriUtils.SCHEME_LOCALUNIT.equals(scheme);
         boolean isNormalized = uri.normalize().toString().equals(str);
         return isValidLength && isValidScheme && isNormalized;
     }
@@ -561,7 +552,7 @@ public final class ODataUtils {
             uri = new URI(str);
             String scheme = uri.getScheme();
             // Scheme check
-            if (!isValidLocalUnitUrlScheme(scheme)) {
+            if (!UriUtils.SCHEME_LOCALUNIT.equals(scheme)) {
                 return false;
             }
             // String length check

--- a/src/main/java/io/personium/core/utils/UriUtils.java
+++ b/src/main/java/io/personium/core/utils/UriUtils.java
@@ -90,10 +90,10 @@ public class UriUtils {
      * @throws URISyntaxException
      */
     public static List<String> getUrlVariations(String url) throws PersoniumCoreException {
-        if (url == null) {
-        	throw PersoniumCoreException.Common.INVALID_URL.params("null");
-        }
         List<String> variations = new ArrayList<String>();
+        if (url == null) {
+            return variations;
+        }
         variations.add(url);
         String substitute = getUrlSubstitute(url);
         if (!url.equals(substitute)) {

--- a/src/main/java/io/personium/core/utils/UriUtils.java
+++ b/src/main/java/io/personium/core/utils/UriUtils.java
@@ -546,4 +546,8 @@ public class UriUtils {
             return false;
         }
     }
+
+    public static String resolveLocalUnit(String url) {
+        return UriUtils.convertSchemeFromLocalUnitToHttp(url);
+    }
 }

--- a/src/main/java/io/personium/core/utils/UriUtils.java
+++ b/src/main/java/io/personium/core/utils/UriUtils.java
@@ -37,25 +37,24 @@ import io.personium.core.PersoniumCoreException;
 import io.personium.core.PersoniumUnitConfig;
 
 /**
- * Scheme Utilities.
- * @author fjqs
+ * Utilities for handling URIs with personium-* scheme.
+ * @author fjqs, shimono
  *
  */
 public class UriUtils {
-    /** PRTCOL HTTP. */
+    /** Scheme string, "http". */
     public static final String SCHEME_HTTP = "http";
-    /** PRTCOL HTTPS. */
+    /** Scheme string, "https". */
     public static final String SCHEME_HTTPS = "https";
-    /** SCHEME URN. */
+    /** Scheme string, "urn". */
     public static final String SCHEME_URN = "urn";
-    /** LOCAL_UNIT. */
+    /** Scheme string, "personium-localunit". */
     public static final String SCHEME_LOCALUNIT = "personium-localunit";
-    /** LOCAL_CELL. */
+    /** Scheme string, "personium-localcell". */
     public static final String SCHEME_LOCALCELL = "personium-localcell";
-    /** LOCAL_BOX. */
+    /** Scheme string, "personium-localbox". */
     public static final String SCHEME_LOCALBOX = "personium-localbox";
 
-    /** LOCAL_UNIT ADDITION. */
     /** LOCAL_CELL ADDITION. */
     public static final String SCHEME_CELL_URI = SCHEME_LOCALCELL + ":/";
     /** LOCAL_BOX ADDITION. */
@@ -70,10 +69,10 @@ public class UriUtils {
     public static final Pattern REGEX_LOCALUNIT_DOUBLE_COLONS
     	= Pattern.compile("^" + SCHEME_LOCALUNIT + ":(.+?):(.*)$");
 
-    /** Regular expression for matching localunit scheme with double colons */
+    /** Regular expression for matching Cell URL */
     public static final String REGEX_HTTP_SUBDOMAIN = "^(http|https):\\/\\/(.+?)\\.(.*)$";
 
-    /** SLASH. */
+    /** String Slash. */
     public static final String STRING_SLASH = "/";
 
     /**
@@ -89,13 +88,13 @@ public class UriUtils {
      * @return ArrayList<String>
      * @throws URISyntaxException
      */
-    public static List<String> getUrlVariations(String unitUrl, String url) throws PersoniumCoreException {
-        if (url == null || unitUrl == null) {
+    public static List<String> getUrlVariations(String url) throws PersoniumCoreException {
+        if (url == null) {
         	throw PersoniumCoreException.Common.INVALID_URL.params("null");
         }
         List<String> variations = new ArrayList<String>();
         variations.add(url);
-        String substitute = getUrlSubstitute(unitUrl, url);
+        String substitute = getUrlSubstitute(url);
         if (!url.equals(substitute)) {
             variations.add(substitute);
         }
@@ -109,14 +108,14 @@ public class UriUtils {
      * @return utl String
      * @throws URISyntaxException
      */
-    public static String getUrlSubstitute(String unitUrl, String url) {
-        if (url == null || unitUrl == null) {
+    public static String getUrlSubstitute(String url) {
+        if (url == null) {
         	throw PersoniumCoreException.Common.INVALID_URL.params("null");
         }
         if (url.startsWith(SCHEME_LOCALUNIT)) {
-            url = convertSchemeFromLocalUnitToHttp(unitUrl, url);
+            url = convertSchemeFromLocalUnitToHttp(url);
         } else {
-            url = convertSchemeFromHttpToLocalUnit(unitUrl, url);
+            url = convertSchemeFromHttpToLocalUnit(url);
         }
         return url;
     }
@@ -139,10 +138,11 @@ public class UriUtils {
      * @param localUnitSchemeUrl local unit url
      * @return url string with http(s) scheme
      */
-    public static String convertSchemeFromLocalUnitToHttp(String unitUrl, String localUnitSchemeUrl) {
-        if (localUnitSchemeUrl == null || unitUrl == null) {
+    public static String convertSchemeFromLocalUnitToHttp(String localUnitSchemeUrl) {
+        if (localUnitSchemeUrl == null) {
         	throw PersoniumCoreException.Common.INVALID_URL.params("null");
         }
+        String unitUrl = PersoniumUnitConfig.getBaseUrl();
         Matcher localUnitDoubleColons = REGEX_LOCALUNIT_DOUBLE_COLONS.matcher(localUnitSchemeUrl);
         Matcher localUnitSingleColon = REGEX_LOCALUNIT_SINGLE_COLON.matcher(localUnitSchemeUrl);
         String pathBased = localUnitSchemeUrl;
@@ -185,10 +185,11 @@ public class UriUtils {
      * @param url target url
      * @return url string with local unit scheme
      */
-    public static String convertSchemeFromHttpToLocalUnit(String unitUrl, String url) {
+    public static String convertSchemeFromHttpToLocalUnit(String url) {
         if (url == null) {
         	throw PersoniumCoreException.Common.INVALID_URL.params("null");
         }
+        String unitUrl = PersoniumUnitConfig.getBaseUrl();
         if (PersoniumUnitConfig.isPathBasedCellUrlEnabled()) {
         	// path based
             if (url.startsWith(unitUrl)) {

--- a/src/main/java/io/personium/core/utils/UriUtils.java
+++ b/src/main/java/io/personium/core/utils/UriUtils.java
@@ -136,7 +136,6 @@ public class UriUtils {
     /**
      * Convert scheme from LocalUnit to http(s).
      * If the he given value does not match localunit schem, the given value is returned as-is.
-     * @param unitUrl unit url
      * @param localUnitSchemeUrl local unit url
      * @return url string with http(s) scheme
      */

--- a/src/main/resources/personium-messages.properties
+++ b/src/main/resources/personium-messages.properties
@@ -370,6 +370,7 @@ io.personium.core.msg.PR409-CM-0002=Because [{0}] is being executed, writing to 
 
 io.personium.core.msg.PR500-CM-0001=Failed to load the request body for some reason.
 io.personium.core.msg.PR500-CM-0002=Files I/O error caused [{0}] to fail.
+io.personium.core.msg.PR500-CM-0003=Invalid URL [{0}] is used internally.
 
 ## Plugin
 # PR500-PL

--- a/src/main/resources/personium-unit-config-default.properties
+++ b/src/main/resources/personium-unit-config-default.properties
@@ -23,7 +23,7 @@
 #################################################
 
 # core version
-io.personium.core.version=1.7.16
+io.personium.core.version=1.7.18
 
 # thread pool num.
 io.personium.core.thread.pool.num.io.cell=10

--- a/src/test/java/io/personium/core/PersoniumUnitConfigTest.java
+++ b/src/test/java/io/personium/core/PersoniumUnitConfigTest.java
@@ -19,13 +19,12 @@ package io.personium.core;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import io.personium.common.utils.PersoniumCoreUtils;
 import io.personium.test.categories.Unit;
@@ -51,8 +50,8 @@ public class PersoniumUnitConfigTest {
 
         PowerMockito.doReturn("host.domain").when(PersoniumCoreUtils.class, "getFQDN");
         PowerMockito.doReturn("https").when(PersoniumUnitConfig.class, "getUnitScheme");
-        PowerMockito.doReturn(-1).when(PersoniumUnitConfig.class, "getUnitPort");
-        assertThat(PersoniumUnitConfig.getBaseUrl(), is("https://host.domain/"));
+        PowerMockito.doReturn(9998).when(PersoniumUnitConfig.class, "getUnitPort");
+        assertThat(PersoniumUnitConfig.getBaseUrl(), is("https://host.domain:9998/"));
 
         PowerMockito.doReturn("host.domain").when(PersoniumCoreUtils.class, "getFQDN");
         PowerMockito.doReturn("http").when(PersoniumUnitConfig.class, "getUnitScheme");

--- a/src/test/java/io/personium/core/auth/AccessContextTest.java
+++ b/src/test/java/io/personium/core/auth/AccessContextTest.java
@@ -241,7 +241,7 @@ public class AccessContextTest {
     public void AuthorizationHeaderなしでのULUUTのcookie認証によるAccessContext生成の正常系テスト() {
         Cell cell = (Cell) mock(Cell.class);
         when(cell.authenticateAccount((OEntityWrapper) Matchers.any(), Matchers.anyString())).thenReturn(true);
-        when(cell.getOwner()).thenReturn("cellowner");
+        when(cell.getOwnerNormalized()).thenReturn("cellowner");
         when(cell.getUrl()).thenReturn(UrlUtils.getBaseUrl() + "/cellowner");
         when(cell.getUnitUrl()).thenReturn(UrlUtils.getBaseUrl());
 
@@ -250,7 +250,7 @@ public class AccessContextTest {
         // uluut発行処理
         UnitLocalUnitUserToken uluut = new UnitLocalUnitUserToken(
                 System.currentTimeMillis(), UnitLocalUnitUserToken.ACCESS_TOKEN_EXPIRES_HOUR * MILLISECS_IN_AN_HOUR,
-                cell.getOwner(), UrlUtils.getBaseUrl());
+                cell.getOwnerNormalized(), UrlUtils.getBaseUrl());
 
         String tokenString = uluut.toTokenString();
         // p_cookie_peerとして、ランダムなUUIDを設定する
@@ -275,13 +275,13 @@ public class AccessContextTest {
 
         Cell cell = (Cell) mock(Cell.class);
         when(cell.authenticateAccount((OEntityWrapper) Matchers.any(), Matchers.anyString())).thenReturn(true);
-        when(cell.getOwner()).thenReturn("cellowner");
+        when(cell.getOwnerNormalized()).thenReturn("cellowner");
         when(cell.getUrl()).thenReturn(UrlUtils.getBaseUrl() + "/cellowner");
         when(cell.getUnitUrl()).thenReturn(UrlUtils.getBaseUrl());
 
         // Token発行処理
         CellLocalAccessToken token = new CellLocalAccessToken(
-                UrlUtils.getBaseUrl() + "/cellowner", cell.getOwner(), null,
+                UrlUtils.getBaseUrl() + "/cellowner", cell.getOwnerNormalized(), null,
                 UrlUtils.getBaseUrl() + "/cellowner");
 
         String tokenString = token.toTokenString();
@@ -305,14 +305,14 @@ public class AccessContextTest {
     public void BASIC認証AuthorizationHeaderとcookie認証情報が同時に指定された場合のAccessContext生成の正常系テスト() {
         Cell cell = (Cell) mock(Cell.class);
         when(cell.authenticateAccount((OEntityWrapper) Matchers.any(), Matchers.anyString())).thenReturn(true);
-        when(cell.getOwner()).thenReturn("cellowner");
+        when(cell.getOwnerNormalized()).thenReturn("cellowner");
 
         UriInfo uriInfo =  new TestUriInfo();
 
         // uluut発行処理
         UnitLocalUnitUserToken uluut = new UnitLocalUnitUserToken(
                 System.currentTimeMillis(), UnitLocalUnitUserToken.ACCESS_TOKEN_EXPIRES_HOUR * MILLISECS_IN_AN_HOUR,
-                cell.getOwner(), uriInfo.getBaseUri().getHost()  + ":"  + uriInfo.getBaseUri().getPort());
+                cell.getOwnerNormalized(), uriInfo.getBaseUri().getHost()  + ":"  + uriInfo.getBaseUri().getPort());
 
         String tokenString = uluut.toTokenString();
         // p_cookie_peerとして、ランダムなUUIDを設定する
@@ -339,14 +339,14 @@ public class AccessContextTest {
     public void マスタトークン認証AuthorizationHeaderとcookie認証情報が同時に指定された場合のAccessContext生成の正常系テスト() {
         Cell cell = (Cell) mock(Cell.class);
         when(cell.authenticateAccount((OEntityWrapper) Matchers.any(), Matchers.anyString())).thenReturn(true);
-        when(cell.getOwner()).thenReturn("cellowner");
+        when(cell.getOwnerNormalized()).thenReturn("cellowner");
 
         UriInfo uriInfo =  new TestUriInfo();
 
         // uluut発行処理
         UnitLocalUnitUserToken uluut = new UnitLocalUnitUserToken(
                 System.currentTimeMillis(), UnitLocalUnitUserToken.ACCESS_TOKEN_EXPIRES_HOUR * MILLISECS_IN_AN_HOUR,
-                cell.getOwner(), uriInfo.getBaseUri().getHost()  + ":"  + uriInfo.getBaseUri().getPort());
+                cell.getOwnerNormalized(), uriInfo.getBaseUri().getHost()  + ":"  + uriInfo.getBaseUri().getPort());
 
         String tokenString = uluut.toTokenString();
         // p_cookie_peerとして、ランダムなUUIDを設定する

--- a/src/test/java/io/personium/core/model/impl/es/odata/MessageODataProducerTest.java
+++ b/src/test/java/io/personium/core/model/impl/es/odata/MessageODataProducerTest.java
@@ -69,7 +69,7 @@ import io.personium.core.utils.UriUtils;
 import io.personium.test.categories.Unit;
 
 /**
- * MessageODataProducerユニットテストクラス.
+ * MessageODataProducer unit tests.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MessageODataProducer.class, Box.class, UriUtils.class })
@@ -820,7 +820,7 @@ public class MessageODataProducerTest {
 
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("http://personium/dummyAppCell/__relation/__/dummyRelation").when(
-                UriUtils.class, "convertSchemeFromLocalUnitToHttp", "http://personium", requestRelation);
+                UriUtils.class, "convertSchemeFromLocalUnitToHttp", requestRelation);
 
         // --------------------
         // Expected result
@@ -862,7 +862,7 @@ public class MessageODataProducerTest {
 
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn(requestRelation).when(
-                UriUtils.class, "convertSchemeFromLocalUnitToHttp", "http://personium", requestRelation);
+                UriUtils.class, "convertSchemeFromLocalUnitToHttp", requestRelation);
 
         // --------------------
         // Expected result
@@ -904,7 +904,7 @@ public class MessageODataProducerTest {
 
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("http://personium/dummyAppCell/__relation/__/dummyRelation").when(
-            UriUtils.class, "convertSchemeFromLocalUnitToHttp", "http://personium", requestRelation);
+            UriUtils.class, "convertSchemeFromLocalUnitToHttp", requestRelation);
 
         Box mockBox = PowerMockito.mock(Box.class);
         doReturn("dummyBoxName").when(mockBox).getName();
@@ -950,7 +950,7 @@ public class MessageODataProducerTest {
 
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn(requestRelation).when(
-                UriUtils.class, "convertSchemeFromLocalUnitToHttp", "http://personium", requestRelation);
+                UriUtils.class, "convertSchemeFromLocalUnitToHttp", requestRelation);
 
         // --------------------
         // Expected result
@@ -992,7 +992,7 @@ public class MessageODataProducerTest {
 
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("http://personium/dummyAppCell/__relation/__/dummyRelation").when(
-                UriUtils.class, "convertSchemeFromLocalUnitToHttp", "http://personium", requestRelation);
+                UriUtils.class, "convertSchemeFromLocalUnitToHttp", requestRelation);
 
         doReturn(null).when(mockCell).getBoxForSchema("http://personium/dummyAppCell/");
 

--- a/src/test/java/io/personium/core/model/impl/es/odata/UnitCtlODataProducerTest.java
+++ b/src/test/java/io/personium/core/model/impl/es/odata/UnitCtlODataProducerTest.java
@@ -84,7 +84,7 @@ public class UnitCtlODataProducerTest {
         doReturn("http://personiumunit/admincell/#admin").when(accessContext).getSubject();
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("personium-localunit:/admincell/#admin").when(UriUtils.class,
-                "convertSchemeFromHttpToLocalUnit", "http://personiumunit/", "http://personiumunit/admincell/#admin");
+                "convertSchemeFromHttpToLocalUnit", "http://personiumunit/admincell/#admin");
 
         Map<String, Object> term1 = new HashMap<>();
         Map<String, Object> term2 = new HashMap<>();

--- a/src/test/java/io/personium/core/model/jaxb/AclTest.java
+++ b/src/test/java/io/personium/core/model/jaxb/AclTest.java
@@ -1,0 +1,52 @@
+package io.personium.core.model.jaxb;
+
+import static org.junit.Assert.assertEquals;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.personium.common.auth.token.TransCellAccessToken;
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.utils.UriUtils;
+
+public class AclTest {
+    private static Logger log = LoggerFactory.getLogger(AclTest.class);
+
+    private static String unitUrl;
+
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Configure PersoniumUnitConfig's BaseUrl
+        TransCellAccessToken.configureX509(PersoniumUnitConfig.getX509PrivateKey(),
+                PersoniumUnitConfig.getX509Certificate(), PersoniumUnitConfig.getX509RootCertificate());
+        unitUrl = PersoniumUnitConfig.getBaseUrl();
+    }
+
+    @Test
+    public void testGetSetBase_localUnitURL_shouldBeStoredUsing_localUnitScheme() throws Exception {
+        Acl acl = new Acl();
+        String unitUrl = PersoniumUnitConfig.getBaseUrl();
+        String mbUrl = unitUrl + "foo/__/";
+        log.info("Configured Unit Url: " + unitUrl);
+        // ---------------
+        acl.setBase(mbUrl);
+        // ---------------
+        // URL Should be innternally
+        JSONObject j = (JSONObject) new JSONParser().parse(acl.toJSON());
+        String baseVal = (String) j.get("@xml.base");
+        log.info(j.toJSONString());
+        log.info("base: " + baseVal);
+        // relativized using localunit scheme
+        assertEquals(UriUtils.convertSchemeFromHttpToLocalUnit(mbUrl), baseVal);
+        // ---------------
+        String retrievedUrl = acl.getBase();
+        // ---------------
+        assertEquals(mbUrl, retrievedUrl);
+    }
+
+}

--- a/src/test/java/io/personium/core/rs/cell/TokenEndPointResourceTest.java
+++ b/src/test/java/io/personium/core/rs/cell/TokenEndPointResourceTest.java
@@ -64,7 +64,7 @@ public class TokenEndPointResourceTest {
      * Before.
      */
     @Before
-    public void befor() {
+    public void before() {
         tokenEndPointResource = spy(new TokenEndPointResource(null, null));
     }
 

--- a/src/test/java/io/personium/core/rs/unit/UnitCtlResourceTest.java
+++ b/src/test/java/io/personium/core/rs/unit/UnitCtlResourceTest.java
@@ -87,7 +87,7 @@ public class UnitCtlResourceTest {
         doReturn("http://personiumunit/").when(accessContext).getBaseUri();
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("personium-localunit:/admincell/#admin").when(UriUtils.class,
-                "convertSchemeFromHttpToLocalUnit", "http://personiumunit/", "http://personiumunit/admincell/#admin");
+                "convertSchemeFromHttpToLocalUnit", "http://personiumunit/admincell/#admin");
 
         doNothing().when(oEntityWrapper).put("Owner", "personium-localunit:/admincell/#admin");
 
@@ -323,7 +323,7 @@ public class UnitCtlResourceTest {
         doReturn("http://personiumunit/").when(ac).getBaseUri();
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("http://personiumunit/admincell/#admin").when(UriUtils.class,
-                "convertSchemeFromLocalUnitToHttp", "http://personiumunit/", "personium-localunit:/admincell/#admin");
+                "convertSchemeFromLocalUnitToHttp", "personium-localunit:/admincell/#admin");
 
         doReturn(AccessContext.TYPE_UNIT_MASTER).when(ac).getType();
 
@@ -362,7 +362,7 @@ public class UnitCtlResourceTest {
         doReturn("http://personiumunit/").when(ac).getBaseUri();
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("http://personiumunit/admincell/#admin").when(UriUtils.class,
-                "convertSchemeFromLocalUnitToHttp", "http://personiumunit/", "personium-localunit:/admincell/#admin");
+                "convertSchemeFromLocalUnitToHttp", "personium-localunit:/admincell/#admin");
 
         doReturn(AccessContext.TYPE_UNIT_USER).when(ac).getType();
 
@@ -403,7 +403,7 @@ public class UnitCtlResourceTest {
         doReturn("http://personiumunit/").when(ac).getBaseUri();
         PowerMockito.mockStatic(UriUtils.class);
         PowerMockito.doReturn("http://personiumunit/admincell/#admin").when(UriUtils.class,
-                "convertSchemeFromLocalUnitToHttp", "http://personiumunit/", "personium-localunit:/admincell/#admin");
+                "convertSchemeFromLocalUnitToHttp", "personium-localunit:/admincell/#admin");
 
         doReturn(AccessContext.TYPE_UNIT_USER).when(ac).getType();
 

--- a/src/test/java/io/personium/core/rule/action/ActionFactoryTest.java
+++ b/src/test/java/io/personium/core/rule/action/ActionFactoryTest.java
@@ -62,7 +62,7 @@ public class ActionFactoryTest {
         // Mock settings
         // --------------------
         Cell cell = mock(Cell.class);
-        doReturn(owner).when(cell).getOwner();
+        doReturn(owner).when(cell).getOwnerNormalized();
         doReturn(cellId).when(cell).getId();
         PowerMockito.spy(LoggerFactory.class);
         PowerMockito.doReturn(null).when(LoggerFactory.class, "getLogger", "io.personium.core.rule.action");
@@ -97,7 +97,7 @@ public class ActionFactoryTest {
         // Mock settings
         // --------------------
         Cell cell = mock(Cell.class);
-        doReturn(owner).when(cell).getOwner();
+        doReturn(owner).when(cell).getOwnerNormalized();
         doReturn(cellId).when(cell).getId();
         PowerMockito.spy(LoggerFactory.class);
         PowerMockito.doReturn(null).when(LoggerFactory.class, "getLogger", "io.personium.core.rule.action");
@@ -132,7 +132,7 @@ public class ActionFactoryTest {
         // Mock settings
         // --------------------
         Cell cell = mock(Cell.class);
-        doReturn(owner).when(cell).getOwner();
+        doReturn(owner).when(cell).getOwnerNormalized();
         doReturn(cellId).when(cell).getId();
         PowerMockito.spy(LoggerFactory.class);
         PowerMockito.doReturn(null).when(LoggerFactory.class, "getLogger", "io.personium.core.rule.action");
@@ -167,7 +167,7 @@ public class ActionFactoryTest {
         // Mock settings
         // --------------------
         Cell cell = mock(Cell.class);
-        doReturn(owner).when(cell).getOwner();
+        doReturn(owner).when(cell).getOwnerNormalized();
         doReturn(cellId).when(cell).getId();
         PowerMockito.spy(LoggerFactory.class);
         PowerMockito.doReturn(null).when(LoggerFactory.class, "getLogger", "io.personium.core.rule.action");
@@ -202,7 +202,7 @@ public class ActionFactoryTest {
         // Mock settings
         // --------------------
         Cell cell = mock(Cell.class);
-        doReturn(owner).when(cell).getOwner();
+        doReturn(owner).when(cell).getOwnerNormalized();
         doReturn(cellId).when(cell).getId();
         PowerMockito.spy(LoggerFactory.class);
         PowerMockito.doReturn(null).when(LoggerFactory.class, "getLogger", "io.personium.core.rule.action");

--- a/src/test/java/io/personium/core/utils/UriUtilsTest.java
+++ b/src/test/java/io/personium/core/utils/UriUtilsTest.java
@@ -99,13 +99,6 @@ public class UriUtilsTest {
              .when(PersoniumUnitConfig.class, "isPathBasedCellUrlEnabled");
         PowerMockito.doReturn("https://host.domain/")
             .when(PersoniumUnitConfig.class, "getBaseUrl");
-        /*
-        PowerMockito.spy(UriUtils.class);
-        PowerMockito.doReturn("http://cell.host.domain/")
-                    .when(UriUtils.class, "convertPathBaseToFqdnBase", "http://host.domain/cell/");
-        PowerMockito.doReturn("https://cell.host.domain/")
-                    .when(UriUtils.class, "convertPathBaseToFqdnBase", "https://host.domain/cell/");
-                    */
 
         // Single Colon
         assertThat(
@@ -161,10 +154,30 @@ public class UriUtilsTest {
     @Test
     public void convertSchemeFromHttpToLocalUnit_Normal_url_is_fqdn_base() throws Exception {
         PowerMockito.spy(PersoniumUnitConfig.class);
+        PowerMockito.doReturn(false)
+            .when(PersoniumUnitConfig.class, "isPathBasedCellUrlEnabled");
         PowerMockito.doReturn("http://unit.example/")
             .when(PersoniumUnitConfig.class, "getBaseUrl");
-        String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://cell.unit.example/");
-        assertThat(actual, is("personium-localunit:cell:/"));
+        assertThat(
+            UriUtils.convertSchemeFromHttpToLocalUnit("http://cell.unit.example/"),
+            is("personium-localunit:cell:/"));
+    }
+    /**
+     * Test convertSchemeFromHttpToLocalUnit().
+     * normal.
+     * url is path base.
+     * @throws Exception exception occurred in some errors
+     */
+    @Test
+    public void convertSchemeFromHttpToLocalUnit_Normal_url_is_path_base() throws Exception {
+        PowerMockito.spy(PersoniumUnitConfig.class);
+        PowerMockito.doReturn(true)
+            .when(PersoniumUnitConfig.class, "isPathBasedCellUrlEnabled");
+        PowerMockito.doReturn("http://unit.example/")
+            .when(PersoniumUnitConfig.class, "getBaseUrl");
+        assertThat(
+            UriUtils.convertSchemeFromHttpToLocalUnit("http://unit.example/cell/"),
+            is("personium-localunit:cell:/"));
     }
 
     /**
@@ -178,11 +191,7 @@ public class UriUtilsTest {
         PowerMockito.spy(PersoniumUnitConfig.class);
         PowerMockito.doReturn("http://unit.example/")
             .when(PersoniumUnitConfig.class, "getBaseUrl");
-/*
-        PowerMockito.spy(UriUtils.class);
-        PowerMockito.doReturn("http://otherdomain/otherhost/cell/")
-                    .when(UriUtils.class, "convertFqdnBaseToPathBase", "http://otherhost.otherdomain/cell/");
-                    */
+
         assertThat(
                 UriUtils.convertSchemeFromHttpToLocalUnit("http://otherhost.otherdomain/cell/"),
                 is("http://otherhost.otherdomain/cell/"));

--- a/src/test/java/io/personium/core/utils/UriUtilsTest.java
+++ b/src/test/java/io/personium/core/utils/UriUtilsTest.java
@@ -18,16 +18,16 @@ package io.personium.core.utils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
-
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import io.personium.core.PersoniumCoreException;
 import io.personium.core.PersoniumUnitConfig;
 import io.personium.test.categories.Unit;
 
@@ -54,6 +54,7 @@ public class UriUtilsTest {
         PowerMockito.doReturn("http://cell.host.domain/")
                     .when(UriUtils.class, "convertPathBaseToFqdnBase", "http://host.domain/cell/");
 
+        // Single Colon
         assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/",
                                                              "personium-localunit:/cell/"),
                    is("http://host.domain/cell/"));
@@ -69,6 +70,22 @@ public class UriUtilsTest {
         assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
                                                              "personium-localunit:/cell/box/col/ent?$inlinecount=allpages"),
                    is("https://host.domain/cell/box/col/ent?$inlinecount=allpages"));
+
+        // Double Colons
+        assertThat(
+        		UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/", "personium-localunit:cell:"),
+        			is("http://host.domain/cell/"));
+        assertThat(
+        		UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:"),
+        		is("https://host.domain/cell/"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:#account"),
+        		is("https://host.domain/cell/#account"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:/box"),
+        		is("https://host.domain/cell/box"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
+        		"personium-localunit:cell:/box/col/ent?$inlinecount=allpages"),
+        		is("https://host.domain/cell/box/col/ent?$inlinecount=allpages"));
+
     }
 
     /**
@@ -88,6 +105,7 @@ public class UriUtilsTest {
         PowerMockito.doReturn("https://cell.host.domain/")
                     .when(UriUtils.class, "convertPathBaseToFqdnBase", "https://host.domain/cell/");
 
+        // Single Colon
         assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/",
                                                              "personium-localunit:/cell/"),
                    is("http://cell.host.domain/"));
@@ -103,6 +121,15 @@ public class UriUtilsTest {
         assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
                                                              "personium-localunit:/cell/box/col/ent?$inlinecount=allpages"),
                    is("https://cell.host.domain/box/col/ent?$inlinecount=allpages"));
+
+        // Double Colons
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/", "personium-localunit:cell:"),
+        	is("http://cell.host.domain/"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:"),
+        	is("https://cell.host.domain/"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:#account"),
+        		is("https://cell.host.domain/#account"));
+
     }
 
     /**
@@ -134,7 +161,7 @@ public class UriUtilsTest {
                     .when(UriUtils.class, "convertFqdnBaseToPathBase", "http://cell.host.domain/");
         String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://host.domain/",
                                                                   "http://cell.host.domain/");
-        assertThat(actual, is("personium-localunit:/cell/"));
+        assertThat(actual, is("personium-localunit:cell:/"));
     }
 
     /**
@@ -161,8 +188,12 @@ public class UriUtilsTest {
      */
     @Test
     public void convertSchemeFromHttpToLocalUnit_Normal_url_is_null() throws Exception {
-        String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://host.domain/", null);
-        assertNull(actual);
+    	try {
+            UriUtils.convertSchemeFromHttpToLocalUnit("http://host.domain/", null);
+    	} catch(PersoniumCoreException e) {
+            assertEquals(e.getCode(), "PR500-CM-0003");
+
+        }
     }
 
     /**

--- a/src/test/java/io/personium/core/utils/UriUtilsTest.java
+++ b/src/test/java/io/personium/core/utils/UriUtilsTest.java
@@ -50,42 +50,40 @@ public class UriUtilsTest {
         PowerMockito.spy(PersoniumUnitConfig.class);
         PowerMockito.doReturn(true)
                     .when(PersoniumUnitConfig.class, "isPathBasedCellUrlEnabled");
-        PowerMockito.spy(UriUtils.class);
-        PowerMockito.doReturn("http://cell.host.domain/")
-                    .when(UriUtils.class, "convertPathBaseToFqdnBase", "http://host.domain/cell/");
+        PowerMockito.doReturn("https://host.domain/")
+        .when(PersoniumUnitConfig.class, "getBaseUrl");
+
 
         // Single Colon
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/",
-                                                             "personium-localunit:/cell/"),
-                   is("http://host.domain/cell/"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/"),
-                   is("https://host.domain/cell/"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/#account"),
-                   is("https://host.domain/cell/#account"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/box"),
-                   is("https://host.domain/cell/box"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/box/col/ent?$inlinecount=allpages"),
-                   is("https://host.domain/cell/box/col/ent?$inlinecount=allpages"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp(
+            "personium-localunit:/cell/"),
+            is("https://host.domain/cell/"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp(
+            "personium-localunit:/cell/"),
+            is("https://host.domain/cell/"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp(
+            "personium-localunit:/cell/#account"),
+            is("https://host.domain/cell/#account"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp(
+            "personium-localunit:/cell/box"),
+            is("https://host.domain/cell/box"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp(
+            "personium-localunit:/cell/box/col/ent?$inlinecount=allpages"),
+            is("https://host.domain/cell/box/col/ent?$inlinecount=allpages"));
 
         // Double Colons
         assertThat(
-        		UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/", "personium-localunit:cell:"),
-        			is("http://host.domain/cell/"));
+            UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:"),
+            is("https://host.domain/cell/"));
         assertThat(
-        		UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:"),
-        		is("https://host.domain/cell/"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:#account"),
-        		is("https://host.domain/cell/#account"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:/box"),
-        		is("https://host.domain/cell/box"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-        		"personium-localunit:cell:/box/col/ent?$inlinecount=allpages"),
-        		is("https://host.domain/cell/box/col/ent?$inlinecount=allpages"));
-
+            UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:"),
+            is("https://host.domain/cell/"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:#account"),
+            is("https://host.domain/cell/#account"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:/box"),
+            is("https://host.domain/cell/box"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:/box/col/ent?$inlinecount=allpages"),
+            is("https://host.domain/cell/box/col/ent?$inlinecount=allpages"));
     }
 
     /**
@@ -98,36 +96,40 @@ public class UriUtilsTest {
     public void convertSchemeFromLocalUnitToHttp_Normal_fqdnBase() throws Exception {
         PowerMockito.spy(PersoniumUnitConfig.class);
         PowerMockito.doReturn(false)
-                    .when(PersoniumUnitConfig.class, "isPathBasedCellUrlEnabled");
+             .when(PersoniumUnitConfig.class, "isPathBasedCellUrlEnabled");
+        PowerMockito.doReturn("https://host.domain/")
+            .when(PersoniumUnitConfig.class, "getBaseUrl");
+        /*
         PowerMockito.spy(UriUtils.class);
         PowerMockito.doReturn("http://cell.host.domain/")
                     .when(UriUtils.class, "convertPathBaseToFqdnBase", "http://host.domain/cell/");
         PowerMockito.doReturn("https://cell.host.domain/")
                     .when(UriUtils.class, "convertPathBaseToFqdnBase", "https://host.domain/cell/");
+                    */
 
         // Single Colon
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/",
-                                                             "personium-localunit:/cell/"),
-                   is("http://cell.host.domain/"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/"),
-                   is("https://cell.host.domain/"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/#account"),
-                   is("https://cell.host.domain/#account"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/box"),
-                   is("https://cell.host.domain/box"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/",
-                                                             "personium-localunit:/cell/box/col/ent?$inlinecount=allpages"),
-                   is("https://cell.host.domain/box/col/ent?$inlinecount=allpages"));
+        assertThat(
+            UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:/cell/"),
+            is("https://cell.host.domain/"));
+        assertThat(
+            UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:/cell/"),
+            is("https://cell.host.domain/"));
+        assertThat(
+            UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:/cell/#account"),
+            is("https://cell.host.domain/#account"));
+        assertThat(
+            UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:/cell/box"),
+            is("https://cell.host.domain/box"));
+        assertThat(
+            UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:/cell/box/col/ent?$inlinecount=allpages"),
+            is("https://cell.host.domain/box/col/ent?$inlinecount=allpages"));
 
         // Double Colons
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("http://host.domain/", "personium-localunit:cell:"),
-        	is("http://cell.host.domain/"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:"),
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:"),
         	is("https://cell.host.domain/"));
-        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("https://host.domain/", "personium-localunit:cell:#account"),
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:"),
+        	is("https://cell.host.domain/"));
+        assertThat(UriUtils.convertSchemeFromLocalUnitToHttp("personium-localunit:cell:#account"),
         		is("https://cell.host.domain/#account"));
 
     }
@@ -140,12 +142,14 @@ public class UriUtilsTest {
      */
     @Test
     public void convertSchemeFromHttpToLocalUnit_Normal_url_starts_with_uniturl() throws Exception {
-        PowerMockito.spy(UriUtils.class);
-        PowerMockito.doReturn("http://host/host/cell/")
-                    .when(UriUtils.class, "convertFqdnBaseToPathBase", "http://host/cell/");
-        String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://host/",
-                                                                  "http://host/cell/");
-        assertThat(actual, is("personium-localunit:/cell/"));
+        PowerMockito.spy(PersoniumUnitConfig.class);
+        PowerMockito.doReturn(false)
+             .when(PersoniumUnitConfig.class, "isPathBasedCellUrlEnabled");
+        PowerMockito.doReturn("https://unit.example/")
+            .when(PersoniumUnitConfig.class, "getBaseUrl");
+        assertThat(
+            UriUtils.convertSchemeFromHttpToLocalUnit("https://unit.example/cell/"),
+            is("personium-localunit:/cell/"));
     }
 
     /**
@@ -156,11 +160,10 @@ public class UriUtilsTest {
      */
     @Test
     public void convertSchemeFromHttpToLocalUnit_Normal_url_is_fqdn_base() throws Exception {
-        PowerMockito.spy(UriUtils.class);
-        PowerMockito.doReturn("http://host.domain/cell/")
-                    .when(UriUtils.class, "convertFqdnBaseToPathBase", "http://cell.host.domain/");
-        String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://host.domain/",
-                                                                  "http://cell.host.domain/");
+        PowerMockito.spy(PersoniumUnitConfig.class);
+        PowerMockito.doReturn("http://unit.example/")
+            .when(PersoniumUnitConfig.class, "getBaseUrl");
+        String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://cell.unit.example/");
         assertThat(actual, is("personium-localunit:cell:/"));
     }
 
@@ -172,12 +175,17 @@ public class UriUtilsTest {
      */
     @Test
     public void convertSchemeFromHttpToLocalUnit_Normal_url_not_starts_with_uniturl() throws Exception {
+        PowerMockito.spy(PersoniumUnitConfig.class);
+        PowerMockito.doReturn("http://unit.example/")
+            .when(PersoniumUnitConfig.class, "getBaseUrl");
+/*
         PowerMockito.spy(UriUtils.class);
         PowerMockito.doReturn("http://otherdomain/otherhost/cell/")
                     .when(UriUtils.class, "convertFqdnBaseToPathBase", "http://otherhost.otherdomain/cell/");
-        String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://host.domain/",
-                                                                  "http://otherhost.otherdomain/cell/");
-        assertThat(actual, is("http://otherhost.otherdomain/cell/"));
+                    */
+        assertThat(
+                UriUtils.convertSchemeFromHttpToLocalUnit("http://otherhost.otherdomain/cell/"),
+                is("http://otherhost.otherdomain/cell/"));
     }
 
     /**
@@ -189,7 +197,7 @@ public class UriUtilsTest {
     @Test
     public void convertSchemeFromHttpToLocalUnit_Normal_url_is_null() throws Exception {
     	try {
-            UriUtils.convertSchemeFromHttpToLocalUnit("http://host.domain/", null);
+            UriUtils.convertSchemeFromHttpToLocalUnit(null);
     	} catch(PersoniumCoreException e) {
             assertEquals(e.getCode(), "PR500-CM-0003");
 
@@ -204,8 +212,7 @@ public class UriUtilsTest {
      */
     @Test
     public void convertSchemeFromHttpToLocalUnit_Normal_url_is_invalid() throws Exception {
-        String actual = UriUtils.convertSchemeFromHttpToLocalUnit("http://host.domain/", "hoge");
-        assertThat(actual, is("hoge"));
+        assertThat(UriUtils.convertSchemeFromHttpToLocalUnit("hoge"), is("hoge"));
     }
 
     /**

--- a/src/test/java/io/personium/test/jersey/bar/BarInstallTest.java
+++ b/src/test/java/io/personium/test/jersey/bar/BarInstallTest.java
@@ -336,7 +336,7 @@ public class BarInstallTest extends PersoniumTest {
     @Test
     public final void メインボックスに対してbarインストールすると405エラーとなること() {
         String reqCell = Setup.TEST_CELL1;
-        String reqPath = Box.DEFAULT_BOX_NAME;
+        String reqPath = Box.MAIN_BOX_NAME;
 
         TResponse res = null;
         File barFile = new File(RESOURCE_PATH + BAR_FILE_MINIMUM);

--- a/src/test/java/io/personium/test/jersey/box/CollectionTest.java
+++ b/src/test/java/io/personium/test/jersey/box/CollectionTest.java
@@ -1482,13 +1482,13 @@ public class CollectionTest extends PersoniumTest {
             Map<String, List<String>> map = new HashMap<String, List<String>>();
             rolList.add("read");
             rolList.add("write");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role1"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role1"), rolList);
             list.add(map);
 
             rolList = new ArrayList<String>();
             map = new HashMap<String, List<String>>();
             rolList.add("read");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role2"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role2"), rolList);
             list.add(map);
 
             list.addAll(createDefaultBoxAceMapList());
@@ -1582,7 +1582,7 @@ public class CollectionTest extends PersoniumTest {
             Map<String, List<String>> map = new HashMap<String, List<String>>();
             List<String> rolList = new ArrayList<String>();
             rolList.add("write");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role1"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role1"), rolList);
             list.add(map);
 
             // top collection ace.
@@ -1590,13 +1590,13 @@ public class CollectionTest extends PersoniumTest {
             map = new HashMap<String, List<String>>();
             rolList.add("read");
             rolList.add("write");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role1"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role1"), rolList);
             list.add(map);
 
             rolList = new ArrayList<String>();
             map = new HashMap<String, List<String>>();
             rolList.add("read");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role2"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role2"), rolList);
             list.add(map);
 
             // box ace.
@@ -1636,14 +1636,14 @@ public class CollectionTest extends PersoniumTest {
         List<String> rolList = new ArrayList<String>();
         Map<String, List<String>> map = new HashMap<String, List<String>>();
         rolList.add("read");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role2"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role2"), rolList);
         list.add(map);
 
         // role3
         rolList = new ArrayList<String>();
         map = new HashMap<String, List<String>>();
         rolList.add("write");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role3"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role3"), rolList);
         list.add(map);
 
         // role4
@@ -1651,42 +1651,42 @@ public class CollectionTest extends PersoniumTest {
         map = new HashMap<String, List<String>>();
         rolList.add("read");
         rolList.add("write");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role4"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role4"), rolList);
         list.add(map);
 
         // role5
         rolList = new ArrayList<String>();
         map = new HashMap<String, List<String>>();
         rolList.add("exec");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role5"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role5"), rolList);
         list.add(map);
 
         // role6
         rolList = new ArrayList<String>();
         map = new HashMap<String, List<String>>();
         rolList.add("read-acl");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role6"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role6"), rolList);
         list.add(map);
 
         // role7
         rolList = new ArrayList<String>();
         map = new HashMap<String, List<String>>();
         rolList.add("write-acl");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role7"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role7"), rolList);
         list.add(map);
 
         // role8
         rolList = new ArrayList<String>();
         map = new HashMap<String, List<String>>();
         rolList.add("write-properties");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role8"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role8"), rolList);
         list.add(map);
 
         // role9
         rolList = new ArrayList<String>();
         map = new HashMap<String, List<String>>();
         rolList.add("read-properties");
-        map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role9"), rolList);
+        map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role9"), rolList);
         list.add(map);
 
         return list;
@@ -1722,7 +1722,7 @@ public class CollectionTest extends PersoniumTest {
             Map<String, List<String>> map = new HashMap<String, List<String>>();
             List<String> rolList = new ArrayList<String>();
             rolList.add("read");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role1"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role1"), rolList);
             list.add(map);
 
             list.addAll(createDefaultBoxAceMapList());
@@ -1777,7 +1777,7 @@ public class CollectionTest extends PersoniumTest {
             Map<String, List<String>> map = new HashMap<String, List<String>>();
             List<String> rolList = new ArrayList<String>();
             rolList.add("exec");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role1"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role1"), rolList);
             list.add(map);
 
             list.addAll(createDefaultBoxAceMapList());
@@ -1835,13 +1835,13 @@ public class CollectionTest extends PersoniumTest {
             List<String> rolList = new ArrayList<String>();
             rolList.add("read");
             rolList.add("write");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role1"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role1"), rolList);
             list.add(map);
 
             List<String> rolList2 = new ArrayList<String>();
             Map<String, List<String>> map2 = new HashMap<String, List<String>>();
             rolList2.add("read");
-            map2.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role2"), rolList2);
+            map2.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role2"), rolList2);
             list.add(map2);
 
             list.addAll(createDefaultBoxAceMapList());
@@ -1989,13 +1989,13 @@ public class CollectionTest extends PersoniumTest {
             List<String> rolList = new ArrayList<String>();
             rolList.add("read");
             rolList.add("write");
-            map.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role1"), rolList);
+            map.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role1"), rolList);
             list.add(map);
 
             List<String> rolList2 = new ArrayList<String>();
             Map<String, List<String>> map2 = new HashMap<String, List<String>>();
             rolList2.add("read");
-            map2.put(UrlUtils.aclRelativePath(Box.DEFAULT_BOX_NAME, "role2"), rolList2);
+            map2.put(UrlUtils.aclRelativePath(Box.MAIN_BOX_NAME, "role2"), rolList2);
             list.add(map2);
 
             TestMethodUtils.aclResponseTest(root2, resorce, list, 1,

--- a/src/test/java/io/personium/test/jersey/box/acl/AclAlterSchemaTest.java
+++ b/src/test/java/io/personium/test/jersey/box/acl/AclAlterSchemaTest.java
@@ -916,7 +916,7 @@ public class AclAlterSchemaTest extends PersoniumTest {
         privileges.add("write");
         privileges.add("alter-schema");
         acl.getAce().add(DavResourceUtils.createAce(false, roleCombPrivilege, privileges));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
 
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, COL_NAME, acl, HttpStatus.SC_OK);
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/MoveCollectionAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/MoveCollectionAccessControlTest.java
@@ -1081,7 +1081,7 @@ public class MoveCollectionAccessControlTest extends PersoniumTest {
         privileges.add("bind");
         privileges.add("unbind");
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_BIND_AND_UNBIND_PREVILEGE, privileges));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
 
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }
@@ -1096,7 +1096,7 @@ public class MoveCollectionAccessControlTest extends PersoniumTest {
     private void setAcl(String collection, String role, String privilege) throws JAXBException {
         Acl acl = new Acl();
         acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/MoveODataCollectionAclTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/MoveODataCollectionAclTest.java
@@ -678,7 +678,7 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
         privileges.add("read");
         privileges.add("write");
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_COMB_PRIVILEGE, privileges));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
 
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }
@@ -693,7 +693,7 @@ public class MoveODataCollectionAclTest extends PersoniumTest {
     private void setAcl(String collection, String role, String privilege) throws JAXBException {
         Acl acl = new Acl();
         acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/MoveServiceCollectionAclTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/MoveServiceCollectionAclTest.java
@@ -677,7 +677,7 @@ public class MoveServiceCollectionAclTest extends PersoniumTest {
         privileges.add("read");
         privileges.add("write");
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_COMB_PRIVILEGE, privileges));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
 
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }
@@ -692,7 +692,7 @@ public class MoveServiceCollectionAclTest extends PersoniumTest {
     private void setAcl(String collection, String role, String privilege) throws JAXBException {
         Acl acl = new Acl();
         acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/ODataCollectionAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/ODataCollectionAccessControlTest.java
@@ -745,7 +745,7 @@ public class ODataCollectionAccessControlTest extends PersoniumTest {
         for (String privilege : privileges) {
             acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
         }
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         return DavResourceUtils.setAcl(token, CELL_NAME, BOX_NAME, collection, acl, code);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/ServiceCollectionAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/ServiceCollectionAccessControlTest.java
@@ -811,7 +811,7 @@ public class ServiceCollectionAccessControlTest extends PersoniumTest {
         for (String privilege : privileges) {
             acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
         }
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         return DavResourceUtils.setAcl(token, CELL_NAME, BOX_NAME, collection, acl, code);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/col/WebDAVCollectionAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/col/WebDAVCollectionAccessControlTest.java
@@ -759,7 +759,7 @@ public class WebDAVCollectionAccessControlTest extends PersoniumTest {
         for (String privilege : privileges) {
             acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
         }
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         return DavResourceUtils.setAcl(token, CELL_NAME, BOX_NAME, collection, acl, code);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/file/FileAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/FileAccessControlTest.java
@@ -1368,7 +1368,7 @@ public class FileAccessControlTest extends PersoniumTest {
         for (String privilege : privileges) {
             acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
         }
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         return DavResourceUtils.setAcl(token, CELL_NAME, BOX_NAME, collection, acl, code);
     }
 

--- a/src/test/java/io/personium/test/jersey/box/dav/file/MoveFileAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/MoveFileAccessControlTest.java
@@ -927,7 +927,7 @@ public class MoveFileAccessControlTest extends PersoniumTest {
         privileges.add("bind");
         privileges.add("unbind");
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_BIND_AND_UNBIND_PREVILEGE, privileges));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
 
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }

--- a/src/test/java/io/personium/test/jersey/box/dav/file/MoveServiceSourceAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/MoveServiceSourceAccessControlTest.java
@@ -777,7 +777,7 @@ public class MoveServiceSourceAccessControlTest extends PersoniumTest {
         privileges.add("read");
         privileges.add("write");
         acl.getAce().add(DavResourceUtils.createAce(false, ROLE_COMB_PRIVILEGE, privileges));
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
 
         DavResourceUtils.setAcl(MASTER_TOKEN, CELL_NAME, BOX_NAME, collection, acl, HttpStatus.SC_OK);
     }

--- a/src/test/java/io/personium/test/jersey/box/dav/file/ServiceSourceAccessControlTest.java
+++ b/src/test/java/io/personium/test/jersey/box/dav/file/ServiceSourceAccessControlTest.java
@@ -779,7 +779,7 @@ public class ServiceSourceAccessControlTest extends PersoniumTest {
         for (String privilege : privileges) {
             acl.getAce().add(DavResourceUtils.createAce(false, role, privilege));
         }
-        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.DEFAULT_BOX_NAME));
+        acl.setXmlbase(String.format("%s/%s/__role/%s/", UrlUtils.getBaseUrl(), CELL_NAME, Box.MAIN_BOX_NAME));
         return DavResourceUtils.setAcl(token, CELL_NAME, BOX_NAME, collection, acl, code);
     }
 

--- a/src/test/java/io/personium/test/jersey/cell/AclTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/AclTest.java
@@ -27,8 +27,12 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -36,11 +40,16 @@ import io.personium.common.utils.PersoniumCoreUtils;
 import io.personium.core.PersoniumCoreException;
 import io.personium.core.auth.OAuth2Helper;
 import io.personium.core.model.Box;
+import io.personium.core.model.Cell;
+import io.personium.core.model.CellCmp;
+import io.personium.core.model.ModelFactory;
 import io.personium.core.model.ctl.Account;
 import io.personium.core.model.ctl.ExtCell;
 import io.personium.core.model.ctl.Relation;
 import io.personium.core.model.ctl.Role;
+import io.personium.core.model.jaxb.Acl;
 import io.personium.core.rs.PersoniumCoreApplication;
+import io.personium.core.utils.UriUtils;
 import io.personium.test.categories.Integration;
 import io.personium.test.categories.Regression;
 import io.personium.test.categories.Unit;
@@ -68,7 +77,7 @@ import io.personium.test.utils.TResponse;
 import io.personium.test.utils.TestMethodUtils;
 
 /**
- * CellレベルACLのテスト.
+ * Cell level ACL testing.
  */
 @Category({Unit.class, Integration.class, Regression.class })
 public class AclTest extends AbstractCase {
@@ -78,8 +87,11 @@ public class AclTest extends AbstractCase {
     static final String TEST_ROLE2 = "role5";
     static final String TOKEN = AbstractCase.MASTER_TOKEN_NAME;
 
+    private static Logger log = LoggerFactory.getLogger(AclTest.class);
+
+
     /**
-     * コンストラクタ.
+     * Constructor.
      */
     public AclTest() {
         super(new PersoniumCoreApplication());
@@ -137,6 +149,38 @@ public class AclTest extends AbstractCase {
                     .with("roleBaseUrl", UrlUtils.roleResource(TEST_CELL1, null, "")).with("level", "").returns()
                     .statusCode(HttpStatus.SC_OK);
         }
+    }
+    /**
+     * Base URL of ACL is stored using localunit scheme whenever possible.
+     * @throws ParseException
+     */
+    @Test
+    public final void baseUrlStoredUsingLocalUnitSchemeWheneverPossible() throws ParseException {
+
+        try {
+            // Configure acl includng role4, role5 onto testcell1
+            Http.request("cell/acl-setting-request.txt").with("url", TEST_CELL1).with("token", TOKEN)
+                    .with("role1", TEST_ROLE1).with("role2", TEST_ROLE2)
+                    .with("roleBaseUrl", UrlUtils.roleResource(TEST_CELL1, null, "")).returns()
+                    .statusCode(HttpStatus.SC_OK);
+
+            Cell cell = ModelFactory.cellFromName(TEST_CELL1);
+            CellCmp cc = ModelFactory.cellCmp(cell);
+            Acl acl = cc.getAcl();
+            log.info(acl.toJSON());
+            JSONObject j = (JSONObject) new JSONParser().parse(acl.toJSON());
+            String base = (String)j.get("@xml.base");
+            assertTrue(base.startsWith(UriUtils.SCHEME_LOCALUNIT));
+
+        } finally {
+            // ACLの設定を元に戻す
+            Http.request("cell/acl-default.txt").with("url", TEST_CELL1).with("token", TOKEN).with("role1", TEST_ROLE1)
+                    .with("role2", TEST_ROLE2).with("box", Setup.TEST_BOX1)
+                    .with("roleBaseUrl", UrlUtils.roleResource(TEST_CELL1, null, "")).with("level", "").returns()
+                    .statusCode(-1);
+        }
+
+
     }
 
     /**
@@ -227,7 +271,7 @@ public class AclTest extends AbstractCase {
                     .with("token", TOKEN)
                     .with("level", "none")
                     .returns()
-                    .statusCode(HttpStatus.SC_OK);
+                    .statusCode(-1);
 
             // Cell ACLの設定を元に戻す
             Http.request("cell/acl-default.txt").with("url", TEST_CELL1)
@@ -237,7 +281,7 @@ public class AclTest extends AbstractCase {
                     .with("box", testBox1)
                     .with("roleBaseUrl", UrlUtils.roleResource(TEST_CELL1, null, ""))
                     .returns()
-                    .statusCode(HttpStatus.SC_OK);
+                    .statusCode(-1);
         }
     }
 
@@ -2110,6 +2154,9 @@ public class AclTest extends AbstractCase {
             RelationUtils.delete(TEST_CELL1, TOKEN, relationName, null, HttpStatus.SC_NO_CONTENT);
         }
     }
+
+
+
 
     private void deleteBox(String boxName, String location) {
 

--- a/src/test/java/io/personium/test/jersey/cell/AclTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/AclTest.java
@@ -128,7 +128,7 @@ public class AclTest extends AbstractCase {
             sb.deleteCharAt(resorce.length() - 1);
 
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                    UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                    UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
         } finally {
             // ACLの設定を元に戻す
@@ -185,7 +185,7 @@ public class AclTest extends AbstractCase {
             StringBuffer sb = new StringBuffer(resorce);
             sb.deleteCharAt(resorce.length() - 1);
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                     UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                     UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
             // Boxの作成
             BoxUtils.create(TEST_CELL1, testBox1, TOKEN);
@@ -282,7 +282,7 @@ public class AclTest extends AbstractCase {
             StringBuffer sb = new StringBuffer(resorce);
             sb.deleteCharAt(resorce.length() - 1);
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                     UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                     UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
             // Boxの作成
             BoxUtils.create(TEST_CELL1, testBox1, TOKEN);
@@ -359,7 +359,7 @@ public class AclTest extends AbstractCase {
             StringBuffer sb = new StringBuffer(resorce);
             sb.deleteCharAt(resorce.length() - 1);
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                     UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                     UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
             // Boxの作成
             BoxUtils.create(TEST_CELL1, testBox1, TOKEN);
@@ -436,7 +436,7 @@ public class AclTest extends AbstractCase {
             StringBuffer sb = new StringBuffer(resorce);
             sb.deleteCharAt(resorce.length() - 1);
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                     UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                     UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
             // Boxの作成
             BoxUtils.create(TEST_CELL1, testBox1, TOKEN);
@@ -557,7 +557,7 @@ public class AclTest extends AbstractCase {
             sb.deleteCharAt(resorce.length() - 1);
 
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                    UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                    UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
         } finally {
             // ACLの設定を元に戻す
@@ -630,7 +630,7 @@ public class AclTest extends AbstractCase {
             sb.deleteCharAt(resorce.length() - 1);
 
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                    UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                    UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
             // PROPPATCH設定実行
             DavResourceUtils.setProppatch(TEST_CELL1, TOKEN, HttpStatus.SC_MULTI_STATUS, "author1", "hoge1");
@@ -667,7 +667,7 @@ public class AclTest extends AbstractCase {
             sb.deleteCharAt(resorce.length() - 1);
 
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                    UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                    UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
         } finally {
             // ACLの設定を元に戻す
             Http.request("cell/acl-default.txt")
@@ -731,7 +731,7 @@ public class AclTest extends AbstractCase {
             sb.deleteCharAt(resorce.length() - 1);
 
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                    UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                    UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
         } finally {
             // ACLの設定を元に戻す
@@ -797,7 +797,7 @@ public class AclTest extends AbstractCase {
             sb.deleteCharAt(resorce.length() - 1);
 
             TestMethodUtils.aclResponseTest(root, sb.toString(), list, 1,
-                    UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, ""), null);
+                    UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, ""), null);
 
         } finally {
             // ロールの削除

--- a/src/test/java/io/personium/test/jersey/cell/BoxUrlTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/BoxUrlTest.java
@@ -137,9 +137,9 @@ public class BoxUrlTest extends ODataCommon {
             HashMap<String, String> requestheaders = new HashMap<String, String>();
             requestheaders.put(HttpHeaders.AUTHORIZATION, BEARER_MASTER_TOKEN);
 
-            String localunitUrl = UriUtils.SCHEME_LOCALUNIT + ":/" + Setup.TEST_CELL_SCHEMA1 + "/";
-            res = rest.getAcceptEncodingGzip(
-                    UrlUtils.boxUrl(Setup.TEST_CELL1, localunitUrl), requestheaders);
+            String localunitUrl = UriUtils.SCHEME_LOCALUNIT + ":" + Setup.TEST_CELL_SCHEMA1 + ":/";
+            String boxUrlApiUrl = UrlUtils.boxUrl(Setup.TEST_CELL1, localunitUrl);
+            res = rest.getAcceptEncodingGzip(boxUrlApiUrl , requestheaders);
             assertEquals(HttpStatus.SC_OK, res.getStatusCode());
             assertEquals(UrlUtils.boxRoot(Setup.TEST_CELL1, Setup.TEST_BOX1 + "/"),
                     res.getFirstHeader(HttpHeaders.LOCATION));

--- a/src/test/java/io/personium/test/jersey/cell/BoxUrlTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/BoxUrlTest.java
@@ -98,7 +98,7 @@ public class BoxUrlTest extends ODataCommon {
             // Setupでセル1にBoxのSchemaとして登録されている urlをhttpからpersonium-localunitに一時的に更新。
             BoxUtils.update(Setup.TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
                     Setup.TEST_BOX1, "*", Setup.TEST_BOX1,
-                    UriUtils.SCHEME_UNIT_URI + Setup.TEST_CELL_SCHEMA1 + "/", HttpStatus.SC_NO_CONTENT);
+                    UriUtils.SCHEME_LOCALUNIT + ":/" + Setup.TEST_CELL_SCHEMA1 + "/", HttpStatus.SC_NO_CONTENT);
 
             // テスト実施
             PersoniumRestAdapter rest = new PersoniumRestAdapter();
@@ -137,7 +137,7 @@ public class BoxUrlTest extends ODataCommon {
             HashMap<String, String> requestheaders = new HashMap<String, String>();
             requestheaders.put(HttpHeaders.AUTHORIZATION, BEARER_MASTER_TOKEN);
 
-            String localunitUrl = UriUtils.SCHEME_UNIT_URI + Setup.TEST_CELL_SCHEMA1 + "/";
+            String localunitUrl = UriUtils.SCHEME_LOCALUNIT + ":/" + Setup.TEST_CELL_SCHEMA1 + "/";
             res = rest.getAcceptEncodingGzip(
                     UrlUtils.boxUrl(Setup.TEST_CELL1, localunitUrl), requestheaders);
             assertEquals(HttpStatus.SC_OK, res.getStatusCode());

--- a/src/test/java/io/personium/test/jersey/cell/BoxUrlTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/BoxUrlTest.java
@@ -88,19 +88,19 @@ public class BoxUrlTest extends ODataCommon {
     }
 
     /**
-     * 指定したローカルユニットschemaのBoxURLがLocalUnitで取得できること.
+     * URL of a box whose Schema URL is personium-localunit scheme should be obtained by querying with Http URL.
      */
     @Test
-    public final void schemaパラメタとしてhttpURLの指定でlocalunitURLをschemaとするBoxが取得できること() {
+    public final void URLofBox_withLocalUnitURLSchema_shouldBeObtainedBy_QueryingWith_HttpURL() {
         try {
-            // テスト準備
-            // スキーマ設定(Box更新)
+            // preparing test
+            // (Update Box and change Schema)
             // Setupでセル1にBoxのSchemaとして登録されている urlをhttpからpersonium-localunitに一時的に更新。
             BoxUtils.update(Setup.TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
                     Setup.TEST_BOX1, "*", Setup.TEST_BOX1,
-                    UriUtils.SCHEME_LOCALUNIT + ":/" + Setup.TEST_CELL_SCHEMA1 + "/", HttpStatus.SC_NO_CONTENT);
+                    UriUtils.SCHEME_LOCALUNIT + ":" + Setup.TEST_CELL_SCHEMA1 + ":/", HttpStatus.SC_NO_CONTENT);
 
-            // テスト実施
+            // Run Test
             PersoniumRestAdapter rest = new PersoniumRestAdapter();
             PersoniumResponse res = null;
 
@@ -117,7 +117,7 @@ public class BoxUrlTest extends ODataCommon {
         } catch (PersoniumException e) {
             fail(e.getMessage());
         } finally {
-            // Box Schema更新（元に戻す）
+            // Update Box Schema (restore)
             BoxUtils.update(Setup.TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME,
                     Setup.TEST_BOX1, "*", Setup.TEST_BOX1,
                     UrlUtils.cellRoot(Setup.TEST_CELL_SCHEMA1), HttpStatus.SC_NO_CONTENT);
@@ -125,10 +125,10 @@ public class BoxUrlTest extends ODataCommon {
     }
 
     /**
-     * schemaパラメタとしてhttpURLの指定でlocalunitURLをschemaとするBoxが取得できること.
+     * URL of a box whose Schema URL is Http scheme should be obtained by querying with personium-localunit URL.
      */
     @Test
-    public final void schemaパラメタとしてlocalunitURLの指定でhttpURLをschemaとするBoxが取得できること() {
+    public final void URLofBox_withHttpURLSchema_shouldBeObtainedBy_QueryingWith_LocalUnitURL() {
         try {
             // Setupを流用
             PersoniumRestAdapter rest = new PersoniumRestAdapter();

--- a/src/test/java/io/personium/test/jersey/cell/DefaultBoxTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/DefaultBoxTest.java
@@ -36,7 +36,7 @@ import io.personium.test.utils.CellUtils;
 import io.personium.test.utils.DavResourceUtils;
 
 /**
- * UnitUserでCellをCRUDするテスト.
+ * MainBoxに関するテスト.
  */
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({Unit.class, Integration.class, Regression.class })
@@ -77,21 +77,21 @@ public class DefaultBoxTest extends PersoniumTest {
     }
 
     /**
-     * セル作成時にデフォルトボックスが生成されることの確認.
+     * セル作成時にMain Boxが生成されることの確認.
      */
     @Test
-    public final void セル作成時にデフォルトボックスが生成されることの確認() {
+    public final void セル作成時にMainBoxが生成されることの確認() {
         try {
             // セル作成
             CellUtils.create(CELL_NAME, TOKEN, HttpStatus.SC_CREATED);
 
             // デフォルトボックスに対してMKCOLを実行して、ボックスの存在及び子要素が作成できることを確認
-            DavResourceUtils.createWebDavCollection("box/mkcol.txt", CELL_NAME, Box.DEFAULT_BOX_NAME + "/" + COL_NAME,
+            DavResourceUtils.createWebDavCollection("box/mkcol.txt", CELL_NAME, Box.MAIN_BOX_NAME + "/" + COL_NAME,
                     TOKEN,
                     HttpStatus.SC_CREATED);
         } finally {
             // コレクションの削除
-            DavResourceUtils.deleteCollection(CELL_NAME, Box.DEFAULT_BOX_NAME, COL_NAME, TOKEN, -1);
+            DavResourceUtils.deleteCollection(CELL_NAME, Box.MAIN_BOX_NAME, COL_NAME, TOKEN, -1);
 
             // セル削除
             CellUtils.delete(TOKEN, CELL_NAME, -1);
@@ -99,24 +99,24 @@ public class DefaultBoxTest extends PersoniumTest {
     }
 
     /**
-     * デフォルトボックス配下にデータが存在するとセルが削除できないことの確認.
+     * Main Box配下にデータが存在するとセルが削除できないことの確認.
      */
     @Test
-    public final void デフォルトボックス配下にデータが存在するとセルが削除できないことの確認() {
+    public final void MainBox配下にデータが存在するとセルが削除できないことの確認() {
         try {
             // セル作成
             CellUtils.create(CELL_NAME, TOKEN, HttpStatus.SC_CREATED);
 
-            // デフォルトボックスにコレクションを作成
-            DavResourceUtils.createWebDavCollection("box/mkcol.txt", CELL_NAME, Box.DEFAULT_BOX_NAME + "/" + COL_NAME,
+            // Main Boxにコレクションを作成
+            DavResourceUtils.createWebDavCollection("box/mkcol.txt", CELL_NAME, Box.MAIN_BOX_NAME + "/" + COL_NAME,
                     TOKEN,
                     HttpStatus.SC_CREATED);
 
-            // デフォルトボックスにコレクションがあるためセル削除が失敗すること
+            // Main Boxにコレクションがあるためセル削除が失敗すること
             CellUtils.delete(TOKEN, CELL_NAME, HttpStatus.SC_CONFLICT);
         } finally {
             // コレクションの削除
-            DavResourceUtils.deleteCollection(CELL_NAME, Box.DEFAULT_BOX_NAME, COL_NAME, TOKEN, -1);
+            DavResourceUtils.deleteCollection(CELL_NAME, Box.MAIN_BOX_NAME, COL_NAME, TOKEN, -1);
 
             // セル削除
             CellUtils.delete(TOKEN, CELL_NAME, -1);

--- a/src/test/java/io/personium/test/jersey/cell/MessageApproveTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/MessageApproveTest.java
@@ -69,14 +69,14 @@ import io.personium.test.utils.RoleUtils;
 import io.personium.test.utils.TResponse;
 
 /**
- * メッセージ承認APIのテスト.
+ * Message Approval API test.
  */
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({Unit.class, Integration.class, Regression.class })
 public class MessageApproveTest extends ODataCommon {
 
     /**
-     * コンストラクタ.
+     * Constructor.
      */
     public MessageApproveTest() {
         super(new PersoniumCoreApplication());

--- a/src/test/java/io/personium/test/jersey/cell/UnitUserCellTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/UnitUserCellTest.java
@@ -95,7 +95,7 @@ public class UnitUserCellTest extends PersoniumTest {
         // Override issuers in unitconfig.
         issuersBackup = PersoniumUnitConfig.get("io.personium.core.unitUser.issuers");
         PersoniumUnitConfig.set("io.personium.core.unitUser.issuers",
-                UriUtils.SCHEME_UNIT_URI + UNIT_USER_CELL + "/");
+        		UriUtils.SCHEME_LOCALUNIT + ":/" + UNIT_USER_CELL + "/");
 
         // Read role name from AccessContext
         Field admin = AccessContext.class.getDeclaredField("ROLE_UNIT_ADMIN");

--- a/src/test/java/io/personium/test/jersey/cell/UnitUserCellTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/UnitUserCellTest.java
@@ -80,7 +80,7 @@ public class UnitUserCellTest extends PersoniumTest {
     private static String issuersBackup = "";
 
     /**
-     * コンストラクタ. テスト対象のパッケージをsuperに渡す必要がある
+     * Constructor. テスト対象のパッケージをsuperに渡す必要がある
      */
     public UnitUserCellTest() {
         super(new PersoniumCoreApplication());
@@ -144,7 +144,7 @@ public class UnitUserCellTest extends PersoniumTest {
     @Test
     public void ユニットユーザートークンでセル作成を行いオーナーが設定されることを確認() {
         try {
-            // 本テスト用セルの作成
+            // 本テスト用 Unit User Cell の作成
             CellUtils.create(UNIT_USER_CELL, AbstractCase.MASTER_TOKEN_NAME, HttpStatus.SC_CREATED);
 
             // アカウント追加

--- a/src/test/java/io/personium/test/jersey/cell/UnitUserCellTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/UnitUserCellTest.java
@@ -31,14 +31,20 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.personium.common.auth.token.AbstractOAuth2Token.TokenDsigException;
 import io.personium.common.auth.token.AbstractOAuth2Token.TokenParseException;
+import io.personium.common.auth.token.AbstractOAuth2Token.TokenRootCrtException;
 import io.personium.common.auth.token.Role;
 import io.personium.common.auth.token.TransCellAccessToken;
 import io.personium.common.auth.token.UnitLocalUnitUserToken;
 import io.personium.core.PersoniumUnitConfig;
 import io.personium.core.auth.AccessContext;
 import io.personium.core.auth.OAuth2Helper;
+import io.personium.core.model.Cell;
+import io.personium.core.model.ModelFactory;
 import io.personium.core.model.ctl.Account;
 import io.personium.core.rs.PersoniumCoreApplication;
 import io.personium.core.utils.UriUtils;
@@ -66,6 +72,8 @@ import io.personium.test.utils.TResponse;
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({Unit.class, Integration.class, Regression.class })
 public class UnitUserCellTest extends PersoniumTest {
+
+    private static Logger log = LoggerFactory.getLogger(UnitUserCellTest.class);
 
     private static final String UNIT_USER_CELL = "unitusercell";
     private static final String UNIT_USER_ACCOUNT = "UnitUserName";
@@ -140,9 +148,70 @@ public class UnitUserCellTest extends PersoniumTest {
 
     /**
      * ユニットユーザートークンでセル作成を行いオーナーが設定されることを確認.
+     * @throws TokenRootCrtException
+     * @throws TokenDsigException
+     * @throws TokenParseException
      */
     @Test
-    public void ユニットユーザートークンでセル作成を行いオーナーが設定されることを確認() {
+    public void ユニットユーザートークンでセル作成を行いオーナーが設定されることを確認() throws TokenParseException, TokenDsigException, TokenRootCrtException {
+        try {
+            // 本テスト用 Unit User Cell の作成
+            CellUtils.create(UNIT_USER_CELL, AbstractCase.MASTER_TOKEN_NAME, -1);
+
+            // アカウント追加
+            AccountUtils.create(AbstractCase.MASTER_TOKEN_NAME, UNIT_USER_CELL,
+                    UNIT_USER_ACCOUNT, UNIT_USER_ACCOUNT_PASS,  -1);
+
+            // 認証（ユニットユーザートークン取得）
+            TResponse res = Http.request("authn/password-tc-c0.txt")
+                    .with("remoteCell", UNIT_USER_CELL)
+                    .with("username", UNIT_USER_ACCOUNT)
+                    .with("password", UNIT_USER_ACCOUNT_PASS)
+                    .with("p_target", UrlUtils.unitRoot())
+                    .returns()
+                    .statusCode(HttpStatus.SC_OK);
+
+            JSONObject json = res.bodyAsJson();
+            String unitUserToken = (String) json.get(OAuth2Helper.Key.ACCESS_TOKEN);
+
+            //
+            TransCellAccessToken tcToken = TransCellAccessToken.parse(unitUserToken);
+            String subject = tcToken.getSubject();
+            log.info("##TOKEN##");
+            log.info("Subject: "+ subject);
+            log.info("Issuer : "+ tcToken.getSubject());
+            log.info("Target : "+ tcToken.getTarget());
+            String localunitSubject = UriUtils.convertSchemeFromHttpToLocalUnit(subject);
+            log.info("Owner Should be : "+ localunitSubject);
+
+            // ユニットユーザートークンを使ってセル作成をする.
+            //   オーナーがユニットユーザー（ここだとuserNameアカウントのURL）になるはず。
+            CellUtils.create(CREATE_CELL, unitUserToken, HttpStatus.SC_CREATED);
+
+            Cell cell = ModelFactory.cellFromName(CREATE_CELL);
+            String owner = cell.getOwnerRaw();
+            log.info(" OWNER = " + owner);
+            assertEquals(localunitSubject, owner);
+
+
+        } finally {
+            // アカウント削除
+            AccountUtils.delete(UNIT_USER_CELL, AbstractCase.MASTER_TOKEN_NAME,
+                    UNIT_USER_ACCOUNT, -1);
+            // 本テスト用セルの削除
+            CellUtils.delete(AbstractCase.MASTER_TOKEN_NAME, CREATE_CELL, -1);
+            CellUtils.delete(AbstractCase.MASTER_TOKEN_NAME, UNIT_USER_CELL, -1);
+        }
+    }
+
+    /**
+     * ユニットユーザートークンでセル作成を行いオーナーとして各種処理が可能なことを確認.
+     * @throws TokenRootCrtException
+     * @throws TokenDsigException
+     * @throws TokenParseException
+     */
+    @Test
+    public void ユニットユーザートークンでセル作成を行いオーナーとして各種処理が可能なことを確認() throws TokenParseException, TokenDsigException, TokenRootCrtException {
         try {
             // 本テスト用 Unit User Cell の作成
             CellUtils.create(UNIT_USER_CELL, AbstractCase.MASTER_TOKEN_NAME, HttpStatus.SC_CREATED);
@@ -163,7 +232,8 @@ public class UnitUserCellTest extends PersoniumTest {
             JSONObject json = res.bodyAsJson();
             String unitUserToken = (String) json.get(OAuth2Helper.Key.ACCESS_TOKEN);
 
-            // ユニットユーザートークンを使ってセル作成をするとオーナーがユニットユーザー（ここだとuserNameアカウントのURL）になるはず。
+            // ユニットユーザートークンを使ってセル作成をする.
+            //   オーナーがユニットユーザー（ここだとuserNameアカウントのURL）になるはず。
             CellUtils.create(CREATE_CELL, unitUserToken, HttpStatus.SC_CREATED);
 
             // ユニットユーザートークンを使ってセル更新ができることを確認
@@ -201,6 +271,7 @@ public class UnitUserCellTest extends PersoniumTest {
             CellUtils.delete(AbstractCase.MASTER_TOKEN_NAME, UNIT_USER_CELL, -1);
         }
     }
+
 
     /**
      * ユニットアドミンロールをもつユニットユーザートークンでセル作成を行いオーナーが設定されないことを確認.

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthCheckTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthCheckTest.java
@@ -101,9 +101,9 @@ public class AuthCheckTest extends PersoniumTest {
     static final String EXTCELL_URL = UrlUtils.extCellResource(CELL_NAME1, UrlUtils.cellRoot(CELL_NAME2));
     static final String ROLE_URI = UrlUtils.roleUrl(CELL_NAME1, null, ROLE_NAME);
     static final String RELATION_BOX_NAME = null;
-    static final String EXTROLE_NAME1 = UrlUtils.roleResource(APP_CELL_NAME, Box.DEFAULT_BOX_NAME, ROLE_NAME1);
-    static final String EXTROLE_NAME2 = UrlUtils.roleResource(CELL_NAME2, Box.DEFAULT_BOX_NAME, ROLE_NAME2);
-    static final String EXTROLE_NAME4 = UrlUtils.roleResource(APP_CELL_NAME, Box.DEFAULT_BOX_NAME, ROLE_NAME4);
+    static final String EXTROLE_NAME1 = UrlUtils.roleResource(APP_CELL_NAME, Box.MAIN_BOX_NAME, ROLE_NAME1);
+    static final String EXTROLE_NAME2 = UrlUtils.roleResource(CELL_NAME2, Box.MAIN_BOX_NAME, ROLE_NAME2);
+    static final String EXTROLE_NAME4 = UrlUtils.roleResource(APP_CELL_NAME, Box.MAIN_BOX_NAME, ROLE_NAME4);
 
     /**
      * コンストラクタ.
@@ -158,7 +158,7 @@ public class AuthCheckTest extends PersoniumTest {
             TransCellAccessToken aToken = TransCellAccessToken.parse(transCellAccessToken);
 
             // 取得トークン内のロール確認
-            assertEquals(UrlUtils.roleResource(testCellName, Box.DEFAULT_BOX_NAME, roleNameNoneBox),
+            assertEquals(UrlUtils.roleResource(testCellName, Box.MAIN_BOX_NAME, roleNameNoneBox),
                     aToken.getRoles().get(0).createUrl());
         } finally {
 
@@ -381,7 +381,7 @@ public class AuthCheckTest extends PersoniumTest {
             String token1RoleUrl = tokenRoles1.get(0).createUrl();
 
             // 取得トークン内のロール確認
-            assertEquals(UrlUtils.roleResource(testCellName1, Box.DEFAULT_BOX_NAME, roleName), token1RoleUrl);
+            assertEquals(UrlUtils.roleResource(testCellName1, Box.MAIN_BOX_NAME, roleName), token1RoleUrl);
 
             // テスト２（user3でのアクセス時にTCAT内にrole2が入っていないこと）
             List<Role> tokenRoles2 = this.checkTransCellAccessToken(testCellName1,
@@ -505,7 +505,7 @@ public class AuthCheckTest extends PersoniumTest {
             // テスト環境がロール１つのため、１以外はテスト失敗
             assertEquals(1, tokenRoles1.size());
             // 取得トークン内のロール確認
-            assertEquals(UrlUtils.roleResource(CELL_NAME1, Box.DEFAULT_BOX_NAME, ROLE_NAME),
+            assertEquals(UrlUtils.roleResource(CELL_NAME1, Box.MAIN_BOX_NAME, ROLE_NAME),
                     tokenRoles1.get(0).createUrl());
 
             // テスト２（user2でのアクセス時にTCAT内にdoctorが入っていること）
@@ -514,7 +514,7 @@ public class AuthCheckTest extends PersoniumTest {
             // テスト環境がロール１つのため、１以外はテスト失敗
             assertEquals(1, tokenRoles2.size());
             // 取得トークン内のロール確認
-            assertEquals(UrlUtils.roleResource(CELL_NAME1, Box.DEFAULT_BOX_NAME, ROLE_NAME),
+            assertEquals(UrlUtils.roleResource(CELL_NAME1, Box.MAIN_BOX_NAME, ROLE_NAME),
                     tokenRoles2.get(0).createUrl());
 
             // テスト３（user3でのアクセス時にTCAT内にdoctorが入っていないこと）

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthCookieTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthCookieTest.java
@@ -568,7 +568,7 @@ public class AuthCookieTest extends PersoniumTest {
 
             // ACL作成
             DavResourceUtils.setACLwithRoleBaseUrl(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, boxName, colName,
-                    "none", UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, "role2"), "<D:read/>",
+                    "none", UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, "role2"), "<D:read/>",
                     HttpStatus.SC_OK);
 
             // パスワード認証要求、クッキーを取得
@@ -607,7 +607,7 @@ public class AuthCookieTest extends PersoniumTest {
 
             // ACL作成
             DavResourceUtils.setACLwithRoleBaseUrl(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, boxName, colName,
-                    "none", UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, "role2"), "<D:read/>",
+                    "none", UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, "role2"), "<D:read/>",
                     HttpStatus.SC_OK);
 
             // パスワード認証要求、クッキーを取得
@@ -660,7 +660,7 @@ public class AuthCookieTest extends PersoniumTest {
 
             // ACL作成
             DavResourceUtils.setACLwithRoleBaseUrl(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, boxName, colName,
-                    "none", UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, "role1"), "<D:read-properties/>",
+                    "none", UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, "role1"), "<D:read-properties/>",
                     HttpStatus.SC_OK);
 
             // パスワード認証要求、クッキーを取得
@@ -701,7 +701,7 @@ public class AuthCookieTest extends PersoniumTest {
 
             // ACL作成
             DavResourceUtils.setACLwithRoleBaseUrl(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, boxName, colName,
-                    "none", UrlUtils.roleResource(TEST_CELL1, Box.DEFAULT_BOX_NAME, "role1"), "<D:read-properties/>",
+                    "none", UrlUtils.roleResource(TEST_CELL1, Box.MAIN_BOX_NAME, "role1"), "<D:read-properties/>",
                     HttpStatus.SC_OK);
 
             // パスワード認証要求、クッキーを取得
@@ -901,7 +901,7 @@ public class AuthCookieTest extends PersoniumTest {
         DavResourceUtils.createODataCollection(AbstractCase.MASTER_TOKEN_NAME, HttpStatus.SC_CREATED, LOCAL_CELL,
                 "box1", "setodata");
         DavResourceUtils.setACLwithRoleBaseUrl(AbstractCase.MASTER_TOKEN_NAME, LOCAL_CELL, "box1", "setodata",
-                "none", UrlUtils.roleResource(LOCAL_CELL, Box.DEFAULT_BOX_NAME, "appadmin"), "<D:read />",
+                "none", UrlUtils.roleResource(LOCAL_CELL, Box.MAIN_BOX_NAME, "appadmin"), "<D:read />",
                 HttpStatus.SC_OK);
     }
 

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthTest.java
@@ -125,7 +125,7 @@ public class AuthTest extends PersoniumTest {
     static final int READ_PROP = 7;
 
     /**
-     * コンストラクタ.
+     * Constructor.
      */
     public AuthTest() {
         super(new PersoniumCoreApplication());
@@ -394,22 +394,23 @@ public class AuthTest extends PersoniumTest {
     public final void ターゲットhttp外部セルのurlがlocalunitの場合でもトークン発行できること_外部セルにロールが直接わりあてられている場合() {
         String httpCell1Url = UrlUtils.cellRoot(TEST_CELL1);
         String httpCell2Url = UrlUtils.cellRoot(TEST_CELL2);
-        String localunitCell1Url = "personium-localunit:/" + TEST_CELL1 + "/";
+        String localunitCell1Url = "personium-localunit:" + TEST_CELL1 + ":/";
         String transCellAccessToken = null;
         String testfile = "testfile.txt";
         String testrole = "transCellTestRole";
         String roleUrl = UrlUtils.roleUrl(TEST_CELL2, null, testrole);
-        // main box を使用（box1にはACL設定がありテストには不適切であるため）
+        // use main box (box1 has ACL settings and not suitable for testing)
         String testBox = "__";
 
-        // dcTargetの値がhttpの場合
+        // When p_target is http URL
         try {
-            // テスト準備  （MASTER_TOKENで実施）
-            // 1.ExtCell更新
-            // Setupでセル２に外部セルとして登録されているセル１のhttpのURLをpersonium-localunitに一時的に更新。
+            // Preparing Test (with MASTER_TOKEN)
+            // 1. Update ExtCell
+            //  temporarily update the preregistered (by Setup) ExtCell entry on cell 2 that points to cell 1
+            //  using http URL, so that it will point to the same cell but using personium-localunit scheme.
             ExtCellUtils.update(MASTER_TOKEN, TEST_CELL2, httpCell1Url, localunitCell1Url, HttpStatus.SC_NO_CONTENT);
 
-            // Role作成
+            //   Create Role
             RoleUtils.create(TEST_CELL2, MASTER_TOKEN, testrole, HttpStatus.SC_CREATED);
 
             // 2.セル2の設定として、この外部セルにロール１を割当。
@@ -518,7 +519,7 @@ public class AuthTest extends PersoniumTest {
     public final void 外部セルのurlがlocalunitの場合でもトークン発行できること_外部セルにリレーションが割り当てられさらにリレーションにロールが割り当てられている場合() {
         String httpCell1Url = UrlUtils.cellRoot(TEST_CELL1);
         String httpCell2Url = UrlUtils.cellRoot(TEST_CELL2);
-        String localunitCell1Url = "personium-localunit:/" + TEST_CELL1 + "/";
+        String localunitCell1Url = "personium-localunit:" + TEST_CELL1 + ":/";
         String transCellAccessToken = null;
         String testfile = "testfile.txt";
         String testrole = "transCellTestRole";
@@ -526,7 +527,7 @@ public class AuthTest extends PersoniumTest {
         // main box を使用（box1にはACL設定がありテストには不適切であるため）
         String testBox = "__";
 
-        // dcTargetの値がhttpの場合
+        // When p_target URL is http
         try {
             // テスト準備  （MASTER_TOKENで実施）
             // 1.ExtCell更新

--- a/src/test/java/io/personium/test/jersey/cell/auth/SchemaAuthTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/SchemaAuthTest.java
@@ -678,16 +678,16 @@ public class SchemaAuthTest extends PersoniumTest {
         try {
             // テスト用のファイルをPUT
             DavResourceUtils.createWebDavFile(TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, "box/dav-put.txt",
-                    "hoge", Box.DEFAULT_BOX_NAME, DAV_RESOURCE, -1);
+                    "hoge", Box.MAIN_BOX_NAME, DAV_RESOURCE, -1);
             // ACL設定
             DavResourceUtils.setACL(TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, HttpStatus.SC_OK, DAV_RESOURCE,
-                    "box/acl-all-none-schema-level.txt", Box.DEFAULT_BOX_NAME, "");
+                    "box/acl-all-none-schema-level.txt", Box.MAIN_BOX_NAME, "");
 
-            this.checkResourcesWithSchema("", DAV_RESOURCE, tokenStr, Box.DEFAULT_BOX_NAME, TEST_CELL1);
+            this.checkResourcesWithSchema("", DAV_RESOURCE, tokenStr, Box.MAIN_BOX_NAME, TEST_CELL1);
         } finally {
             // テスト用のファイルを削除
             DavResourceUtils.deleteWebDavFile("box/dav-delete.txt", Setup.TEST_CELL1,
-                    AbstractCase.MASTER_TOKEN_NAME, DAV_RESOURCE, -1, Box.DEFAULT_BOX_NAME);
+                    AbstractCase.MASTER_TOKEN_NAME, DAV_RESOURCE, -1, Box.MAIN_BOX_NAME);
         }
     }
 

--- a/src/test/java/io/personium/test/jersey/cell/auth/token/TokenIssuanceTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/token/TokenIssuanceTest.java
@@ -1,0 +1,169 @@
+/**
+ * Personium
+ * Copyright 2019 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.jersey.cell.auth.token;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.personium.common.auth.token.AbstractOAuth2Token.TokenDsigException;
+import io.personium.common.auth.token.AbstractOAuth2Token.TokenParseException;
+import io.personium.common.auth.token.AbstractOAuth2Token.TokenRootCrtException;
+import io.personium.common.auth.token.AccountAccessToken;
+import io.personium.common.auth.token.TransCellAccessToken;
+import io.personium.core.rs.PersoniumCoreApplication;
+import io.personium.core.utils.HttpClientFactory;
+import io.personium.core.utils.UriUtils;
+import io.personium.test.categories.Integration;
+import io.personium.test.categories.Regression;
+import io.personium.test.categories.Unit;
+import io.personium.test.jersey.PersoniumIntegTestRunner;
+import io.personium.test.jersey.PersoniumTest;
+import io.personium.test.setup.Setup;
+
+/**
+ * Tests about tokens issuance at the Token Endpoint.
+ */
+@RunWith(PersoniumIntegTestRunner.class)
+@Category({Unit.class, Integration.class, Regression.class })
+public class TokenIssuanceTest extends PersoniumTest {
+
+    static final int MILLISECS_IN_AN_MINITE = 60 * 1000;
+    private static Logger log = LoggerFactory.getLogger(TokenIssuanceTest.class);
+
+
+    /**
+     * Constructor.
+     */
+    public TokenIssuanceTest() {
+        super(new PersoniumCoreApplication());
+    }
+
+    /**
+     * When p_target is localunit scheme URL, then Trans-Cell Access Token issued should have http scheme audience.
+     * @throws IOException
+     * @throws ClientProtocolException
+     * @throws TokenRootCrtException
+     * @throws TokenDsigException
+     * @throws TokenParseException
+     */
+    @Test
+    public final void When_PTargetLocalunitSchemeURL_Then_TCATShouldHaveAudienceHttpSchemeURL () throws ClientProtocolException, IOException, TokenParseException, TokenDsigException, TokenRootCrtException {
+        String cellUrl = UriUtils.SCHEME_LOCALUNIT + ":" + Setup.TEST_CELL1 + ":/";
+        String targetUrl = UriUtils.SCHEME_LOCALUNIT + ":" + Setup.TEST_CELL2 + ":/";
+        cellUrl = UriUtils.resolveLocalUnit(cellUrl);
+        String at = this.callROPC(cellUrl, "account1", "password1", targetUrl).getString("access_token");
+        TransCellAccessToken tcat = TransCellAccessToken.parse(at);
+        String aud = tcat.getTarget();
+        log.info(aud);
+
+        assertFalse(aud.startsWith(UriUtils.SCHEME_LOCALUNIT));
+        assertTrue(aud.startsWith("http"));
+    }
+
+
+    /**
+     * When client_id is localunit scheme URL, then app auth should still work.
+     * @throws IOException
+     * @throws ClientProtocolException
+     * @throws TokenRootCrtException
+     * @throws TokenDsigException
+     * @throws TokenParseException
+     */
+    @Test
+    public final void When_ClientIdLocalunitSchemeURL_Then_StillTheAppAuthShouldWork () throws ClientProtocolException, IOException, TokenParseException, TokenDsigException, TokenRootCrtException {
+        String appCellLocalUnit = UriUtils.SCHEME_LOCALUNIT + ":" + Setup.TEST_CELL_SCHEMA1 + ":/";
+        String usrCellLocalUnit = UriUtils.SCHEME_LOCALUNIT + ":" + Setup.TEST_CELL1 + ":/";
+        String appCellUrl = UriUtils.resolveLocalUnit(appCellLocalUnit);
+        String usrCellUrl = UriUtils.resolveLocalUnit(usrCellLocalUnit);
+
+        String clientSecret = this.callROPC(appCellUrl, "account1", "password1", usrCellUrl).getString("access_token");
+        String at = this.callROPC(usrCellUrl, "account1", "password1", null, appCellLocalUnit, clientSecret).getString("access_token");
+        log.info("token:" + at);
+
+        AccountAccessToken aat = AccountAccessToken.parse(at, usrCellUrl);
+
+        String schema = aat.getSchema();
+        log.info(schema);
+        assertTrue(schema.startsWith(appCellUrl));
+    }
+
+    private JsonObject callROPC(String cellUrl, String username, String password, String pTarget)
+            throws ClientProtocolException, IOException {
+        return callROPC(cellUrl, username, password, pTarget, null, null);
+    }
+
+    private JsonObject callROPC(String cellUrl, String username, String password, String pTarget, String clientId, String clientSecret)
+            throws ClientProtocolException, IOException {
+        HttpClient client = HttpClientFactory.create(HttpClientFactory.TYPE_DEFAULT);
+
+        String tokenEndpoint = cellUrl + "__token";
+        log.info("Testing against: " + tokenEndpoint);
+
+        HttpPost post = new HttpPost(tokenEndpoint);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("grant_type=password&username=");
+        sb.append(username);
+        sb.append("&password=");
+        sb.append(password);
+        if (pTarget != null) {
+            sb.append("&p_target=");
+            sb.append(pTarget);
+        }
+        if (clientId != null) {
+            sb.append("&client_id=");
+            sb.append(clientId);
+            sb.append("&client_secret=");
+            sb.append(clientSecret);
+        }
+
+        post.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
+        post.setHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
+
+        HttpEntity reqEntity = new StringEntity(sb.toString());
+        post.setEntity(reqEntity);
+        HttpResponse res = client.execute(post);
+
+        try (InputStream is = res.getEntity().getContent()){
+            return Json.createReader(is).readObject();
+        }
+    }
+
+
+
+}
+

--- a/src/test/java/io/personium/test/jersey/cell/auth/token/TokenTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/token/TokenTest.java
@@ -47,7 +47,7 @@ import io.personium.test.utils.Http;
 import io.personium.test.utils.ResourceUtils;
 
 /**
- * トークンのテスト.
+ * Access Token Acceptance test.
  */
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({Unit.class, Integration.class, Regression.class })
@@ -62,7 +62,7 @@ public class TokenTest extends PersoniumTest {
     static final int MILLISECS_IN_AN_MINITE = 60 * 1000;
 
     /**
-     * コンストラクタ.
+     * Constructor.
      */
     public TokenTest() {
         super(new PersoniumCoreApplication());

--- a/src/test/java/io/personium/test/setup/Setup.java
+++ b/src/test/java/io/personium/test/setup/Setup.java
@@ -357,7 +357,7 @@ public class Setup extends AbstractCase {
         for (int i = 0; i < NUM_ROLES; i++) {
             // ExtRole作成
             ExtRoleConfig extRole = new ExtRoleConfig();
-            extRole.extRole = UrlUtils.roleResource(extCell, Box.DEFAULT_BOX_NAME, "role" + i);
+            extRole.extRole = UrlUtils.roleResource(extCell, Box.MAIN_BOX_NAME, "role" + i);
             extRole.relationName = CELL_RELATION;
             extRole.relationBoxName = null;
             extRoles.add(extRole);

--- a/src/test/java/io/personium/test/unit/core/UrlUtils.java
+++ b/src/test/java/io/personium/test/unit/core/UrlUtils.java
@@ -444,7 +444,7 @@ public final class UrlUtils {
     public static String roleResource(final String cellName, final String boxName, final String roleName) {
         String box = null;
         if (boxName == null) {
-            box = Box.DEFAULT_BOX_NAME;
+            box = Box.MAIN_BOX_NAME;
         } else {
             box = boxName;
         }

--- a/src/test/java/io/personium/test/unit/core/UrlUtils.java
+++ b/src/test/java/io/personium/test/unit/core/UrlUtils.java
@@ -502,7 +502,7 @@ public final class UrlUtils {
      * @return unit local RelationClassURL
      */
     public static String unitLocalRelationClassUrl(final String cellName, final String relationName) {
-        return String.format("%s%s/__relation/__/%s", UriUtils.SCHEME_UNIT_URI, cellName, relationName);
+        return String.format("%s%s/__relation/__/%s", UriUtils.SCHEME_LOCALUNIT + ":/", cellName, relationName);
     }
 
     /**
@@ -522,7 +522,7 @@ public final class UrlUtils {
      * @return unit local RoleClassURL
      */
     public static String unitLocalRoleClassUrl(final String cellName, final String roleName) {
-        return String.format("%s%s/__role/__/%s", UriUtils.SCHEME_UNIT_URI, cellName, roleName);
+        return String.format("%s%s/__role/__/%s", UriUtils.SCHEME_LOCALUNIT + ":/", cellName, roleName);
     }
 
     /**

--- a/src/test/java/io/personium/test/utils/AuthzUtils.java
+++ b/src/test/java/io/personium/test/utils/AuthzUtils.java
@@ -341,8 +341,8 @@ public class AuthzUtils {
 
         paramsList.add(AuthResourceUtils.getJavascript("ajax.js"));
         paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
-        paramsList.add(clientId + Box.DEFAULT_BOX_NAME + "/profile.json");
-        paramsList.add(cellUrl + Box.DEFAULT_BOX_NAME + "/profile.json");
+        paramsList.add(clientId + Box.MAIN_BOX_NAME + "/profile.json");
+        paramsList.add(cellUrl + Box.MAIN_BOX_NAME + "/profile.json");
         paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
         paramsList.add(cellUrl + "__authz");
         paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0002"));
@@ -378,8 +378,8 @@ public class AuthzUtils {
 
         paramsList.add(AuthResourceUtils.getJavascript("ajax.js"));
         paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
-        paramsList.add(clientId + Box.DEFAULT_BOX_NAME + "/profile.json");
-        paramsList.add(cellUrl + Box.DEFAULT_BOX_NAME + "/profile.json");
+        paramsList.add(clientId + Box.MAIN_BOX_NAME + "/profile.json");
+        paramsList.add(cellUrl + Box.MAIN_BOX_NAME + "/profile.json");
         paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0001"));
         paramsList.add(cellUrl + "__authz");
         paramsList.add(PersoniumCoreMessageUtils.getMessage("PS-AU-0006"));


### PR DESCRIPTION
fix for Issue #284 

- [x] Cell owner : Type A. 
- [x] ACL base : Type A
- [x] ExtCell.Url : Type B
- [x] Box.Schema : Type B

- Type A:  URL persisted using localunit whenever possible via conversion
- Type B:  URL persisted as-is. interpreted at evaluation.

This PR also includes the following refactoring.

- DEFAULT_BOX is old name for MAIN_BOX so the constant is renamed.
- Unit URL can now be retrieved from PersoniumUnitConfig
