### PR TITLE
Implement for relaying request of dynamic path service execution.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,6 @@
                     </includes>
                     <excludes>
                         <exclude>**/revproxy/AcceptEncodingTest.java</exclude>
-                        <exclude>**/engine/ServiceRelayTest.java</exclude>
                         <exclude>**/performance/**/*Test.java</exclude>
                         <!-- Tests that fail when running tests from outside for various reasons. -->
                         <!-- TODO Should be fixed so that all tests are successful. -->

--- a/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
+++ b/src/main/java/io/personium/core/rs/box/PersoniumEngineSvcCollectionResource.java
@@ -292,7 +292,7 @@ public class PersoniumEngineSvcCollectionResource {
      * @param headers header
      * @return JAX-RS Response
      */
-    @Path("{path}")
+    @Path("{path:.+}")
     @GET
     public Response relayget(@PathParam("path") String path,
             @Context final UriInfo uriInfo,
@@ -311,7 +311,7 @@ public class PersoniumEngineSvcCollectionResource {
      * @return JAX-RS Response
      */
     @WriteAPI
-    @Path("{path}")
+    @Path("{path:.+}")
     @POST
     public Response relaypost(@PathParam("path") String path,
             @Context final UriInfo uriInfo,
@@ -331,7 +331,7 @@ public class PersoniumEngineSvcCollectionResource {
      * @return JAX-RS Response
      */
     @WriteAPI
-    @Path("{path}")
+    @Path("{path:.+}")
     @PUT
     public Response relayput(@PathParam("path") String path,
             @Context final UriInfo uriInfo,
@@ -350,7 +350,7 @@ public class PersoniumEngineSvcCollectionResource {
      * @return JAX-RS Response
      */
     @WriteAPI
-    @Path("{path}")
+    @Path("{path:.+}")
     @DELETE
     public Response relaydelete(@PathParam("path") String path,
             @Context final UriInfo uriInfo,

--- a/src/test/java/io/personium/test/engine/ServiceRelayTestBase.java
+++ b/src/test/java/io/personium/test/engine/ServiceRelayTestBase.java
@@ -72,7 +72,7 @@ public abstract class ServiceRelayTestBase extends PersoniumTest {
         + "}";
 
     /** レスポンスヘッダーのチェック項目. */
-    protected static final String[] CHECK_HEADERS = {"x-baseurl",
+    private static final String[] CHECK_HEADERS = {"x-baseurl",
             "x-request-uri",
             "x-personium-fs-path",
             "x-personium-fs-routing-id",
@@ -82,10 +82,20 @@ public abstract class ServiceRelayTestBase extends PersoniumTest {
             "user-agent",
             "x-personium-requestkey"};
 
+    /**
+     * Method called when test class configures service endpoint
+     */
     abstract void configureService();
 
+    /**
+     * Method called when test class deconfigures service endpoint
+     */
     abstract void deconfigureService();
 
+    /**
+     * Method called when test class decides the endpoint to execute
+     * @return relative path in service collection to execute
+     */
     abstract String getPathToExecute();
 
     /**

--- a/src/test/java/io/personium/test/engine/ServiceRelayTestBase.java
+++ b/src/test/java/io/personium/test/engine/ServiceRelayTestBase.java
@@ -45,11 +45,11 @@ import io.personium.test.utils.TResponse;
  */
 @RunWith(PersoniumIntegTestRunner.class)
 @Category({Integration.class, Regression.class })
-public class ServiceRelayTest extends PersoniumTest {
+public abstract class ServiceRelayTestBase extends PersoniumTest {
     /**
      * コンストラクタ.
      */
-    public ServiceRelayTest() {
+    public ServiceRelayTestBase() {
         super(new PersoniumCoreApplication());
     }
 
@@ -72,41 +72,28 @@ public class ServiceRelayTest extends PersoniumTest {
         + "}";
 
     /** レスポンスヘッダーのチェック項目. */
-    private static final String[] CHECK_HEADERS = {"x-baseurl",
+    protected static final String[] CHECK_HEADERS = {"x-baseurl",
             "x-request-uri",
-            "x-dc-es-index",
-            "x-dc-es-id",
-            "x-dc-es-type",
+            "x-personium-fs-path",
+            "x-personium-fs-routing-id",
             "host",
             "connection",
             "authorization",
             "user-agent",
-            "X-Personium-RequestKey"};
+            "x-personium-requestkey"};
+
+    abstract void configureService();
+
+    abstract void deconfigureService();
+
+    abstract String getPathToExecute();
 
     /**
      * 事前準備.
      */
     @Before
     public final void before() {
-        // PropPatch サービス設定の登録
-        Http.request("box/proppatch-set-service.txt")
-                .with("path", "service_relay")
-                .with("token", AbstractCase.MASTER_TOKEN_NAME)
-                .with("name", "relay")
-                .with("src", "relay.js")
-                .returns()
-                .statusCode(HttpStatus.SC_MULTI_STATUS);
-
-        // WebDAV サービスリソースの登録
-        Http.request("box/dav-put.txt")
-                .with("cellPath", "testcell1")
-                .with("path", "service_relay/__src/relay.js")
-                .with("token", AbstractCase.MASTER_TOKEN_NAME)
-                .with("box", "box1")
-                .with("contentType", "text/javascript")
-                .with("source", SOURCE)
-                .returns()
-                .statusCode(HttpStatus.SC_CREATED);
+        this.configureService();
     }
 
     /**
@@ -114,14 +101,7 @@ public class ServiceRelayTest extends PersoniumTest {
      */
     @After
     public final void after() {
-        // WebDAV サービスリソースの削除
-        Http.request("box/dav-delete.txt")
-                .with("cellPath", "testcell1")
-                .with("path", "service_relay/__src/relay.js")
-                .with("token", AbstractCase.MASTER_TOKEN_NAME)
-                .with("box", "box1")
-                .returns()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
+        this.deconfigureService();
     }
 
     /**
@@ -210,15 +190,26 @@ public class ServiceRelayTest extends PersoniumTest {
     }
 
     /**
-     * レスポンスのチェック.
+     * Execute service with checking result status code.
      */
     private void exexServiceWithCheck(String method, String body, String query) {
+        execServiceWithCheck(method, this.getPathToExecute(), body, query);
+    }
+
+    /**
+     * Execute service with checking status code
+     * @param method
+     * @param path
+     * @param body
+     * @param query
+     */
+    private void execServiceWithCheck(String method, String path, String body, String query) {
         // リクエストの実行
         String requestQuery = "";
         if (query.length() != 0) {
             requestQuery = "?" + query;
         }
-        TResponse response = execService(method, body, requestQuery, AbstractCase.MASTER_TOKEN_NAME, HttpStatus.SC_OK);
+        TResponse response = execService(method, path, body, requestQuery, AbstractCase.MASTER_TOKEN_NAME, HttpStatus.SC_OK);
 
         // レスポンスのチェック
         JSONObject checkObj = response.bodyAsJson();
@@ -226,23 +217,38 @@ public class ServiceRelayTest extends PersoniumTest {
         assertEquals((String) checkObj.get("body"), body);
         assertEquals((String) checkObj.get("query"), query);
         JSONObject headerObj = (JSONObject) checkObj.get("header");
+        System.out.println(headerObj);
         for (String key : CHECK_HEADERS) {
             assertNotNull(headerObj.get(key));
         }
     }
 
     /**
-     * サービスリクエストを実行する.
-     * @param method リクエストメソッド
-     * @param body リクエストボディ
-     * @param requestQuery リクエストクエリ
-     * @param token 認証トークン
-     * @param code 期待するレスポンスコード
+     * Function for send service request
+     * @param method Method of request
+     * @param body Request body
+     * @param requestQuery Request query
+     * @param token authentication token
+     * @param code expected status code of response
      * @return
      */
     private TResponse execService(String method, String body, String requestQuery, String token, int code) {
+        return execService(method, this.getPathToExecute(), body, requestQuery, token, code);
+    }
+
+    /**
+     * Function for send service request
+     * @param method Method of request
+     * @param path Request path
+     * @param body Request body
+     * @param requestQuery Request query
+     * @param token authentication token
+     * @param code expected status code of response
+     * @return
+     */
+    protected TResponse execService(String method, String path, String body, String requestQuery, String token, int code) {
         TResponse response = Http.request("box/service-exec.txt")
-                .with("path", "service_relay/relay")
+                .with("path", path)
                 .with("token", token)
                 .with("method", method)
                 .with("body", body)

--- a/src/test/java/io/personium/test/engine/ServiceRelayTestDynamic.java
+++ b/src/test/java/io/personium/test/engine/ServiceRelayTestDynamic.java
@@ -1,0 +1,85 @@
+/**
+ * Personium
+ * Copyright 2014-2020 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.engine;
+
+import org.apache.http.HttpStatus;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import io.personium.test.categories.Integration;
+import io.personium.test.categories.Regression;
+import io.personium.test.jersey.AbstractCase;
+import io.personium.test.jersey.PersoniumIntegTestRunner;
+import io.personium.test.utils.Http;
+
+/**
+ * サービス実行のリレーテスト.
+ */
+@RunWith(PersoniumIntegTestRunner.class)
+@Category({Integration.class, Regression.class })
+public class ServiceRelayTestDynamic extends ServiceRelayTestBase {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void configureService() {
+        // PropPatch サービス設定の登録
+        Http.request("box/proppatch-set-service.txt")
+                .with("path", "service_relay")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("name", "relay/{id: [0-9]+}/test")
+                .with("src", "relay.js")
+                .returns()
+                .statusCode(HttpStatus.SC_MULTI_STATUS);
+
+        // WebDAV サービスリソースの登録
+        Http.request("box/dav-put.txt")
+                .with("cellPath", "testcell1")
+                .with("path", "service_relay/__src/relay.js")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("box", "box1")
+                .with("contentType", "text/javascript")
+                .with("source", SOURCE)
+                .returns()
+                .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void deconfigureService() {
+        // WebDAV サービスリソースの削除
+        Http.request("box/dav-delete.txt")
+                .with("cellPath", "testcell1")
+                .with("path", "service_relay/__src/relay.js")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("box", "box1")
+                .returns()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    String getPathToExecute() {
+        return "service_relay/relay/1234/test";
+    }
+}

--- a/src/test/java/io/personium/test/engine/ServiceRelayTestStatic.java
+++ b/src/test/java/io/personium/test/engine/ServiceRelayTestStatic.java
@@ -1,0 +1,85 @@
+/**
+ * Personium
+ * Copyright 2014-2020 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.engine;
+
+import org.apache.http.HttpStatus;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import io.personium.test.categories.Integration;
+import io.personium.test.categories.Regression;
+import io.personium.test.jersey.AbstractCase;
+import io.personium.test.jersey.PersoniumIntegTestRunner;
+import io.personium.test.utils.Http;
+
+/**
+ * サービス実行のリレーテスト.
+ */
+@RunWith(PersoniumIntegTestRunner.class)
+@Category({Integration.class, Regression.class })
+public class ServiceRelayTestStatic extends ServiceRelayTestBase {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void configureService() {
+        // PropPatch サービス設定の登録
+        Http.request("box/proppatch-set-service.txt")
+                .with("path", "service_relay")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("name", "relay")
+                .with("src", "relay.js")
+                .returns()
+                .statusCode(HttpStatus.SC_MULTI_STATUS);
+
+        // WebDAV サービスリソースの登録
+        Http.request("box/dav-put.txt")
+                .with("cellPath", "testcell1")
+                .with("path", "service_relay/__src/relay.js")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("box", "box1")
+                .with("contentType", "text/javascript")
+                .with("source", SOURCE)
+                .returns()
+                .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void deconfigureService() {
+        // WebDAV サービスリソースの削除
+        Http.request("box/dav-delete.txt")
+                .with("cellPath", "testcell1")
+                .with("path", "service_relay/__src/relay.js")
+                .with("token", AbstractCase.MASTER_TOKEN_NAME)
+                .with("box", "box1")
+                .returns()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    String getPathToExecute() {
+        return "service_relay/relay";
+    }
+}


### PR DESCRIPTION

Related to https://github.com/personium/personium-engine/pull/130 , this PR enables dynamic endpoint in service collection.

And I modified some test codes which were disabled due to incompability between personium versions. (This commit https://github.com/personium/personium-core/commit/e085b1ad3039b3c8685a7ed101822ad763eb77cb is related, maybe)
You have to use personium-engine version 1.5.28-SNAPSHOT in testing.