### PR TITLE
Make OIDC plugin available for multiple IdP.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,14 +227,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.11.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>3.11.2</version>
-            <scope>test</scope>
+            <version>2.28.2</version>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
         <dependency>
             <groupId>io.personium</groupId>
             <artifactId>personium-plugin-base</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.personium</groupId>
             <artifactId>personium-plugins</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.7-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>3.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/personium/core/PersoniumUnitConfig.java
+++ b/src/main/java/io/personium/core/PersoniumUnitConfig.java
@@ -83,6 +83,9 @@ public class PersoniumUnitConfig {
     /** Plugin path setting key.*/
     public static final String PLUGIN_PATH = KEY_ROOT + "plugin.path";
 
+    /** Plugin classname loaded by default. */
+    public static final String PLUGIN_DEFAULT_LOAD_CLASSNAME = KEY_ROOT + "plugin.defaultClassname";
+
     /**
      * Cell configurations.
      */
@@ -898,6 +901,13 @@ public class PersoniumUnitConfig {
      */
     public static String getPluginPath() {
         return get(PLUGIN_PATH);
+    }
+
+    /**
+     * @return plugin's classname loaded by deafult
+     */
+    public static String getPluginDefaultLoadClassname() {
+        return get(PLUGIN_DEFAULT_LOAD_CLASSNAME);
     }
 
     /**

--- a/src/main/java/io/personium/core/plugin/PluginFactory.java
+++ b/src/main/java/io/personium/core/plugin/PluginFactory.java
@@ -26,10 +26,17 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Plugin Factory.
  */
 public class PluginFactory {
+
+    /** Logger. */
+    static Logger log = LoggerFactory.getLogger(PluginFactory.class);
+
     /** instance. */
     private static PluginFactory instance = new PluginFactory();
     private JarFile jar;
@@ -72,34 +79,29 @@ public class PluginFactory {
                 URL url = file.getCanonicalFile().toURI().toURL();
                 ucl = new URLClassLoader(new URL[] {url}, getClass().getClassLoader());
 
-                System.out.println(ucl.getURLs().toString());
                 Class<?> clazz = ucl.loadClass(cname);
                 if (clazz != null) {
                     plugin = (Object) clazz.newInstance();
                 }
-                System.out.println("Plugin Factory load jar file...... " + cname);
+                log.info("Plugin Factory load jar file...... " + cname);
             } catch (ClassNotFoundException e) {
-                System.out.println("Plugin Factory ClassNotFoundException : class name = " + cname);
-                e.printStackTrace();
+                log.info("ClassNotFoundException: class name = " + cname, e);
             } catch (NoClassDefFoundError e) {
-                System.out.println("Plugin Factory NoClassDefFoundError : class name = " + cname);
-                e.printStackTrace();
+                log.info("NoClassDefFoundError: class name = " + cname, e);
             } catch (NullPointerException e) {
-                e.printStackTrace();
+                log.info("NullPointerExecption: class name = " + cname, e);
             } catch (SecurityException e) {
-                e.printStackTrace();
+                log.info("SecurityException: class name = " + cname, e);
             } catch (ExceptionInInitializerError e) {
-                e.printStackTrace();
+                log.info("ExceptionInInitializerError: class name = " + cname, e);
             } catch (InstantiationException e) {
-                System.out.println(
-                    "Plugin Factory InstantiationException : Instance can not be created class name = " + cname);
-                e.printStackTrace();
+                log.info("Plugin Factory InstantiationException : Instance can not be created class name = " + cname,
+                        e);
             } catch (IllegalArgumentException e) {
-                e.printStackTrace();
+                log.info("IllegalArgumentException: class name = " + cname, e);
             }
-
         } catch (Exception e) {
-            e.printStackTrace();
+            log.info(e.getMessage(), e);
             return null;
         }
         return plugin;
@@ -115,7 +117,7 @@ public class PluginFactory {
         Object plugin = null;
         try {
             // MANIFEST.MF
-            File mfile = new File(cpath + File.separator + dname +  File.separator + "META-INF/MANIFEST.MF");
+            File mfile = new File(cpath + File.separator + dname + File.separator + "META-INF/MANIFEST.MF");
             in = new BufferedReader(new FileReader(mfile));
             in.readLine();
             String line = in.readLine();
@@ -129,17 +131,17 @@ public class PluginFactory {
             Class<?> objFile = ucl2.loadClass(cname);
             if (objFile != null) {
                 plugin = (Object) objFile.newInstance();
-                System.out.println("Plugin Factory load directory..... " + cname);
+                log.info("Plugin Factory load directory..... " + cname);
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.info(e.getMessage(), e);
         }
         return plugin;
     }
 
     /**
-     * Loading default auth plugin which is included in personium-plugin.jar
+     * Loading default auth plugin which is included in personium-plugin.jar.
      * @param name default class name
      * @return obj
      */
@@ -151,14 +153,14 @@ public class PluginFactory {
             clazz = Class.forName(name);
             obj = clazz.newInstance();
         } catch (ClassNotFoundException e) {
-            //Class does not exist
-            e.printStackTrace();
+            // Class does not exist
+            log.info("ClassNotFoundException: class name = " + name, e);
         } catch (InstantiationException e) {
-            //Instance can not be created
-            e.printStackTrace();
+            // Instance can not be created
+            log.info("InstantiationException: class name = " + name, e);
         } catch (IllegalAccessException e) {
-            //Invocation: Access violation, protected
-            e.printStackTrace();
+            // Invocation: Access violation, protected
+            log.info("IllegalAccessException: class name = " + name, e);
         }
         return obj;
     }

--- a/src/main/java/io/personium/core/plugin/PluginFactory.java
+++ b/src/main/java/io/personium/core/plugin/PluginFactory.java
@@ -139,20 +139,17 @@ public class PluginFactory {
     }
 
     /**
-     * loadDefault.
-     * @param name String
+     * Loading default auth plugin which is included in personium-plugin.jar
+     * @param name default class name
      * @return obj
      */
     public Object loadDefaultPlugin(String name) {
         Object obj = null;
-        // personium-core pox.xml
-        // original plug-in
-        // set personium-plugins jar
+
         try {
             Class<?> clazz;
             clazz = Class.forName(name);
             obj = clazz.newInstance();
-
         } catch (ClassNotFoundException e) {
             //Class does not exist
             e.printStackTrace();

--- a/src/main/java/io/personium/core/plugin/PluginsLoader.java
+++ b/src/main/java/io/personium/core/plugin/PluginsLoader.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 
+import io.personium.core.PersoniumUnitConfig;
 import io.personium.plugin.base.auth.AuthPluginLoader;
 
 /**
@@ -29,11 +30,33 @@ import io.personium.plugin.base.auth.AuthPluginLoader;
  */
 public class PluginsLoader {
 
-    static final String PLUGIN_DEFAULT_LOAD = 
-           "io.personium.plugin.auth.oidc.OIDCPluginLoader";
+    /** Plugin Classname loaded by default. */
+    private String defaultLoadClassname = null;
+
+    /**
+     * Default constructor The plugin classname loaded by default is set same as
+     * PersoniumConfig.
+     */
+    public PluginsLoader() {
+        this(PersoniumUnitConfig.getPluginDefaultLoadClassname());
+    }
+
+    /**
+     * Constructor to specify plugin classname loaded by default.
+     *
+     * @param defaultLoadedPluginClassname Plugin classname loaded by default
+     */
+    public PluginsLoader(String defaultLoadedPluginClassname) {
+        if (defaultLoadedPluginClassname == null) {
+            this.defaultLoadClassname = "io.personium.plugin.auth.oidc.OIDCPluginLoader";
+        } else {
+            this.defaultLoadClassname = defaultLoadedPluginClassname;
+        }
+    }
 
     /**
      * Return together an instance of the plug-in class to an ArrayList.
+     *
      * @param cpath String
      * @return ArrayList
      */
@@ -43,7 +66,7 @@ public class PluginsLoader {
         // Load jar(maven) specified in pom.xml
         try {
             // personium-plugins original
-            String className = PLUGIN_DEFAULT_LOAD;
+            String className = this.defaultLoadClassname;
             PluginFactory pf = new PluginFactory();
             Object obj = pf.loadDefaultPlugin(className);
             if (obj != null) {
@@ -88,14 +111,15 @@ public class PluginsLoader {
 
     /**
      * createPluginInfo.
+     *
      * @param plugin Plugin
-     * @param name String
+     * @param name   String
      * @return pi PluginInfo
      */
     public ArrayList<PluginInfo> createPluginInfo(Object plugin, String name) {
         ArrayList<PluginInfo> results = new ArrayList<PluginInfo>();
         if (plugin instanceof AuthPluginLoader) {
-            AuthPluginLoader loader = (AuthPluginLoader)plugin;
+            AuthPluginLoader loader = (AuthPluginLoader) plugin;
             for (Object obj : loader.loadInstances()) {
                 results.add(new PluginInfo(obj, name));
             }

--- a/src/main/java/io/personium/core/plugin/PluginsLoader.java
+++ b/src/main/java/io/personium/core/plugin/PluginsLoader.java
@@ -18,15 +18,19 @@
 package io.personium.core.plugin;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+
+import io.personium.plugin.base.auth.AuthPluginLoader;
 
 /**
  * Plugins Loader.
  */
 public class PluginsLoader {
 
-    static final String PLUGIN_AUTH_GOOGLE =
-           "io.personium.plugin.auth.oidc.GoogleIdTokenAuthPlugin";
+    static final String PLUGIN_DEFAULT_LOAD = 
+           "io.personium.plugin.auth.oidc.OIDCPluginLoader";
 
     /**
      * Return together an instance of the plug-in class to an ArrayList.
@@ -39,11 +43,11 @@ public class PluginsLoader {
         // Load jar(maven) specified in pom.xml
         try {
             // personium-plugins original
-            String className = PLUGIN_AUTH_GOOGLE;
+            String className = PLUGIN_DEFAULT_LOAD;
             PluginFactory pf = new PluginFactory();
             Object obj = pf.loadDefaultPlugin(className);
             if (obj != null) {
-                plugins.add(createPluginInfo(obj, className));
+                plugins.addAll(createPluginInfo(obj, className));
             }
         } catch (Exception ex) {
             System.out.println(ex.getMessage());
@@ -54,9 +58,9 @@ public class PluginsLoader {
             File f = new File(cpath);
             String[] files = f.list();
             for (int i = 0; i < files.length; i++) {
-                PluginInfo pinfo = null;
+                ArrayList<PluginInfo> pinfo = null;
                 String fname = files[i];
-                if (fname.endsWith(".jar")) {
+                if (!Files.isDirectory(Paths.get(cpath, fname)) && fname.endsWith(".jar")) {
                     // File *.jar
                     File file = new File(cpath + File.separator + files[i]);
                     if (file.isFile()) {
@@ -73,7 +77,7 @@ public class PluginsLoader {
                     pinfo = createPluginInfo(obj, obj.getClass().getName());
                 }
                 if (pinfo != null) {
-                    plugins.add(pinfo);
+                    plugins.addAll(pinfo);
                 }
             }
         } catch (Exception ex) {
@@ -88,8 +92,17 @@ public class PluginsLoader {
      * @param name String
      * @return pi PluginInfo
      */
-    public PluginInfo createPluginInfo(Object plugin, String name) {
-        return new PluginInfo(plugin, name);
+    public ArrayList<PluginInfo> createPluginInfo(Object plugin, String name) {
+        ArrayList<PluginInfo> results = new ArrayList<PluginInfo>();
+        if (plugin instanceof AuthPluginLoader) {
+            AuthPluginLoader loader = (AuthPluginLoader)plugin;
+            for (Object obj : loader.loadInstances()) {
+                results.add(new PluginInfo(obj, name));
+            }
+        } else {
+            results.add(new PluginInfo(plugin, name));
+        }
+        return results;
     }
 
 }

--- a/src/main/resources/personium-unit-config-default.properties
+++ b/src/main/resources/personium-unit-config-default.properties
@@ -40,6 +40,7 @@ io.personium.core.pathBasedCellUrl.enabled=false
 
 # plugin
 io.personium.core.plugin.path=/personium/personium-core/plugins
+io.personium.core.plugin.defaultClassname=io.personium.plugin.auth.oidc.OIDCPluginLoader
 
 # engine configurations
 io.personium.core.engine.host=localhost

--- a/src/test/java/io/personium/core/plugin/AuthPluginForTesting.java
+++ b/src/test/java/io/personium/core/plugin/AuthPluginForTesting.java
@@ -1,0 +1,99 @@
+/**
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.plugin;
+
+import java.util.List;
+import java.util.Map;
+
+import io.personium.plugin.base.auth.AuthConst;
+import io.personium.plugin.base.auth.AuthPlugin;
+import io.personium.plugin.base.auth.AuthPluginException;
+import io.personium.plugin.base.auth.AuthenticatedIdentity;
+
+/**
+ * Dummy AuthPlugin class for testing.
+ */
+public class AuthPluginForTesting implements AuthPlugin {
+
+    /** default grantType. */
+    public static final String DEFAULT_GRANT_TYPE = "urn:x-personium:test:defaultgrant";
+
+    /** default accountType. */
+    public static final String DEFAULT_ACCOUNT_TYPE = "accountTypeForTesting";
+
+    /** specified grantType. */
+    private String grantType = DEFAULT_GRANT_TYPE;
+
+    /** specified accountType. */
+    private String accountType = DEFAULT_ACCOUNT_TYPE;
+
+    /**
+     * default constructor.
+     */
+    public AuthPluginForTesting() {
+
+    }
+
+    /**
+     * constructor for setting custom values.
+     *
+     * @param grantType   grantType which this instance returns
+     * @param accountType accountType which this instance returns
+     */
+    public AuthPluginForTesting(String grantType, String accountType) {
+        if (grantType != null) {
+            this.grantType = grantType;
+        }
+        if (accountType != null) {
+            this.accountType = accountType;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getType() {
+        return AuthConst.PLUGIN_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getGrantType() {
+        return grantType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAccountType() {
+        return accountType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticatedIdentity authenticate(Map<String, List<String>> body) throws AuthPluginException {
+        return null;
+    }
+
+}

--- a/src/test/java/io/personium/core/plugin/AuthPluginLoaderForTesting.java
+++ b/src/test/java/io/personium/core/plugin/AuthPluginLoaderForTesting.java
@@ -1,0 +1,49 @@
+/**
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.plugin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.personium.plugin.base.auth.AuthPlugin;
+import io.personium.plugin.base.auth.AuthPluginLoader;
+
+/**
+ * Dummy AuthPluginLoader class for testing.
+ */
+public class AuthPluginLoaderForTesting implements AuthPluginLoader {
+
+    /** GrantTypes of authPlugin created. */
+    public static final Set<String> DEFAULT_GRANT_TYPES = new HashSet<String>(
+            Arrays.asList("grantType001", "grantType002"));
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ArrayList<AuthPlugin> loadInstances() {
+        ArrayList<AuthPlugin> results = new ArrayList<AuthPlugin>();
+        for (String grantType : DEFAULT_GRANT_TYPES) {
+            results.add(new AuthPluginForTesting(grantType, "accountType_for_" + grantType));
+        }
+        return results;
+    }
+
+}

--- a/src/test/java/io/personium/core/plugin/PluginManagerTest.java
+++ b/src/test/java/io/personium/core/plugin/PluginManagerTest.java
@@ -84,7 +84,7 @@ public class PluginManagerTest {
      */
     @Test
     public void PluginManager_returns_null_if_invalid_grantType() throws Exception {
-        String invalidGratType = "urn:x-dc1:oidc:hoge:code";
+        String invalidGrantType = "urn:x-dc1:oidc:hoge:code";
 
         PluginManager pm = new PluginManager();
         assertTrue("PluginManager failed to load plugins", (pm.size() > 0));

--- a/src/test/java/io/personium/core/plugin/PluginManagerTest.java
+++ b/src/test/java/io/personium/core/plugin/PluginManagerTest.java
@@ -89,7 +89,7 @@ public class PluginManagerTest {
         PluginManager pm = new PluginManager();
         assertTrue("PluginManager failed to load plugins", (pm.size() > 0));
 
-        PluginInfo pi = pm.getPluginsByGrantType(invalidGratType);
+        PluginInfo pi = pm.getPluginsByGrantType(invalidGrantType);
         assertNull("PluginManager returns not null", pi);
     }
 

--- a/src/test/java/io/personium/core/plugin/PluginManagerTest.java
+++ b/src/test/java/io/personium/core/plugin/PluginManagerTest.java
@@ -1,0 +1,118 @@
+/**
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.plugin;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.plugin.base.auth.AuthConst;
+import io.personium.test.categories.Unit;
+
+/**
+ * Test class of PluginManager.
+ */
+@Category({ Unit.class })
+public class PluginManagerTest {
+
+    private static String previousConfig = null;
+
+    /**
+     * Preparation before executing this test class.
+     */
+    @BeforeClass
+    public static void prepare() {
+        previousConfig = PersoniumUnitConfig.getPluginDefaultLoadClassname();
+        PersoniumUnitConfig.set(PersoniumUnitConfig.PLUGIN_DEFAULT_LOAD_CLASSNAME,
+                AuthPluginLoaderForTesting.class.getName());
+    }
+
+    /**
+     * Clean up after executing this test class.
+     */
+    @AfterClass
+    public static void cleanup() {
+        if (previousConfig == null) {
+            PersoniumUnitConfig.getProperties().remove(PersoniumUnitConfig.PLUGIN_DEFAULT_LOAD_CLASSNAME);
+        } else {
+            PersoniumUnitConfig.set(PersoniumUnitConfig.PLUGIN_DEFAULT_LOAD_CLASSNAME, previousConfig);
+        }
+    }
+
+    /**
+     * Test that PluginManager can find correct plugin by grantType.
+     *
+     * @throws Exception .
+     */
+    @Test
+    public void PluginManger_can_find_AuthPlugin_by_grantType() throws Exception {
+        String testGrantType = AuthPluginLoaderForTesting.DEFAULT_GRANT_TYPES.iterator().next();
+        PluginManager pm = new PluginManager();
+        assertTrue("PluginManager failed to load plugins", (pm.size() > 0));
+
+        PluginInfo pi = (PluginInfo) pm.getPluginsByGrantType(testGrantType);
+        assertNotNull("getPluginsByGrantType [" + testGrantType + "] returns null", pi);
+    }
+
+    /**
+     * Test that PluginManager returns null if invalid grantType is presented.
+     *
+     * @throws Exception .
+     */
+    @Test
+    public void PluginManager_returns_null_if_invalid_grantType() throws Exception {
+        String invalidGratType = "urn:x-dc1:oidc:hoge:code";
+
+        PluginManager pm = new PluginManager();
+        assertTrue("PluginManager failed to load plugins", (pm.size() > 0));
+
+        PluginInfo pi = pm.getPluginsByGrantType(invalidGratType);
+        assertNull("PluginManager returns not null", pi);
+    }
+
+    /**
+     * PluginManager_can_returns_list_of_AuthPlugin.
+     *
+     * @throws Exception .
+     */
+    @Test
+    public void PluginManager_can_returns_list_of_AuthPlugin() throws Exception {
+        boolean bFind = true;
+
+        PluginManager pm = new PluginManager();
+        List<PluginInfo> pl = pm.getPluginsByType(AuthConst.PLUGIN_TYPE);
+
+        assertTrue("PluginManager returns 0 plugin.", (pl.size() > 0));
+        for (int i = 0; i < pl.size(); i++) {
+            PluginInfo pi = (PluginInfo) pl.get(i);
+            if (!pi.getType().equals(AuthConst.PLUGIN_TYPE)) {
+                bFind = false;
+            }
+        }
+        assertTrue(bFind);
+    }
+
+}

--- a/src/test/java/io/personium/core/plugin/PluginsLoaderTest.java
+++ b/src/test/java/io/personium/core/plugin/PluginsLoaderTest.java
@@ -1,0 +1,135 @@
+/**
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.plugin;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.plugin.base.auth.AuthPlugin;
+import io.personium.plugin.base.utils.PluginUtils;
+import io.personium.test.categories.Unit;
+
+/**
+ * Test for PluginLoader class.
+ */
+@Category({ Unit.class })
+public class PluginsLoaderTest {
+
+    /**
+     * Check if PluginLoader can load specified AuthPlugin (single).
+     * @throws Exception .
+     */
+    @Test
+    public void PluginsLoader_loads_single_AuthPlugin() throws Exception {
+        PluginsLoader pl = new PluginsLoader(AuthPluginForTesting.class.getName());
+        ArrayList<PluginInfo> arrPI = pl.loadPlugins(PersoniumUnitConfig.getPluginPath());
+
+        boolean bFind = false;
+        for (PluginInfo pluginInfo : arrPI) {
+            if (pluginInfo != null) {
+                AuthPlugin ap = (AuthPlugin) pluginInfo.getObj();
+                String gtype = ap.getGrantType();
+                if (AuthPluginForTesting.DEFAULT_GRANT_TYPE.equals(gtype)) {
+                    bFind = true;
+                }
+            }
+        }
+        assertTrue(AuthPluginForTesting.class.getName() + " is not found", bFind);
+    }
+
+    /**
+     * Check if PluginLoader can load specified AuthPlugin (multiple).
+     * @throws Exception .
+     */
+    @Test
+    public void PluginsLoader_loads_multiple_AuthPlugin() throws Exception {
+        PluginsLoader pl = new PluginsLoader(AuthPluginLoaderForTesting.class.getName());
+        ArrayList<PluginInfo> arrPI = pl.loadPlugins(PersoniumUnitConfig.getPluginPath());
+
+        Set<String> foundGrantType = new HashSet<String>();
+        for (PluginInfo pluginInfo : arrPI) {
+            if (pluginInfo != null) {
+                AuthPlugin ap = (AuthPlugin) pluginInfo.getObj();
+                String gtype = ap.getGrantType();
+                foundGrantType.add(gtype);
+            }
+        }
+        assertTrue("Found grantTypes " + foundGrantType + " is not matched with "
+                + "AuthPluginsLoaderForTesting.defaultGrantTypes " + AuthPluginLoaderForTesting.DEFAULT_GRANT_TYPES,
+                foundGrantType.containsAll(AuthPluginLoaderForTesting.DEFAULT_GRANT_TYPES));
+    }
+
+    /**
+     * Check if PluginsLoader can load default plugin.
+     * @throws Exception .
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void PluginManager_loads_default_plugin() throws Exception {
+        MockedStatic<PluginUtils> mocked = Mockito.mockStatic(PluginUtils.class);
+
+        // For testing, http requests return dummy
+        // as default plugin uses Http Requests during its initialization.
+        JSONObject dummyConfig = new JSONObject();
+        dummyConfig.put("jwks_uri", "https://localhost/jwks");
+        mocked.when(() -> {
+            PluginUtils.getHttpJSON(Mockito.anyString());
+        }).thenReturn(dummyConfig);
+
+        String keyConfigurationFile = "io.personium.configurationFile";
+
+        String prevConfig = System.getProperty(keyConfigurationFile);
+        System.setProperty(keyConfigurationFile, "personium-unit-config-oidcpluginloadertest.properties");
+
+        try {
+            PluginManager pm = new PluginManager();
+            boolean bHit = (pm.size() > 0);
+
+            Set<String> grantTypes = new HashSet<String>(Arrays.asList("grantType001", "grantType002", "grantType004"));
+
+            // all plugins for specified grantTypes are loaded
+            for (String grantType : grantTypes) {
+                PluginInfo pi = (PluginInfo) pm.getPluginsByGrantType(grantType);
+                if (pi != null) {
+                    System.out.println("OK get grant_type = " + grantType);
+                } else {
+                    bHit = false;
+                }
+            }
+            assertTrue(bHit);
+        } finally {
+            if (prevConfig == null) {
+                System.clearProperty(keyConfigurationFile);
+            } else {
+                System.setProperty(keyConfigurationFile, prevConfig);
+            }
+        }
+    }
+
+}

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthErrorTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthErrorTest.java
@@ -36,6 +36,7 @@ import io.personium.test.categories.Unit;
 import io.personium.test.jersey.AbstractCase;
 import io.personium.test.jersey.PersoniumIntegTestRunner;
 import io.personium.test.jersey.PersoniumTest;
+import io.personium.test.jersey.plugin.AuthPluginForAuthTest;
 import io.personium.test.utils.AccountUtils;
 import io.personium.test.utils.Http;
 import io.personium.test.utils.TResponse;
@@ -61,15 +62,15 @@ public class AuthErrorTest extends PersoniumTest {
     }
 
     /**
-     * Testing for returning 400 when unsupported grant_type is passed
+     * Testing for returning 400 when unsupported grant_type is passed.
      */
     @Test
     public final void Returns400_WhenUnsupportedGrantTypesIsPassed() {
-        String unsupported_grant_type = "unsupported_grant_type_test";
+        String unsupportedGrantType = "unsupported_grant_type_test";
 
         TResponse res = Http.request("authn/auth.txt")
                 .with("remoteCell", TEST_CELL1)
-                .with("body", "grant_type=" + unsupported_grant_type)
+                .with("body", "grant_type=" + unsupportedGrantType)
                 .returns()
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
 
@@ -79,7 +80,7 @@ public class AuthErrorTest extends PersoniumTest {
             .getCode();
         String message = PersoniumCoreAuthnException
             .UNSUPPORTED_GRANT_TYPE
-            .params(unsupported_grant_type)
+            .params(unsupportedGrantType)
             .getMessage();
 
         String errDesc = String.format("[%s] - %s", code, message);
@@ -115,7 +116,7 @@ public class AuthErrorTest extends PersoniumTest {
     @Test
     public final void Typeがoidc系のみのアカウントに対しパスワード認証をしようとするとエラーが返ること() {
         String accountName = "NonBasicTypeAccount";
-        String type = "oidc:google";
+        String type = AuthPluginForAuthTest.ACCOUNT_TYPE;
         String pass = "dammypasswd";
         try {
             AccountUtils.createWithType(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, type, accountName,

--- a/src/test/java/io/personium/test/jersey/cell/auth/AuthOidcTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/auth/AuthOidcTest.java
@@ -30,6 +30,7 @@ import io.personium.test.categories.Unit;
 import io.personium.test.jersey.AbstractCase;
 import io.personium.test.jersey.PersoniumIntegTestRunner;
 import io.personium.test.jersey.PersoniumTest;
+import io.personium.test.jersey.plugin.AuthPluginForAuthTest;
 import io.personium.test.utils.AccountUtils;
 import io.personium.test.utils.Http;
 
@@ -91,11 +92,12 @@ public class AuthOidcTest extends PersoniumTest {
     public final void 不正なIDTokenを指定し400エラーが返却されること()
             throws InterruptedException {
         String accountName = "invalidIdTokenAccount";
+        String accountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         try {
             // テスト用のアカウントを作成
             // 他のテストと共用するAccountを使用すると、認証失敗のロックがかかり、テストが失敗する。このため、このテスト独自のAccountを作成する
             AccountUtils.createNonCredentialWithType(AbstractCase.MASTER_TOKEN_NAME,
-                    TEST_CELL1, accountName, "oidc:google", HttpStatus.SC_CREATED);
+                    TEST_CELL1, accountName, accountType, HttpStatus.SC_CREATED);
 
             Http.request("authn/oidc-auth.txt")
                     .with("remoteCell", TEST_CELL1)
@@ -115,11 +117,12 @@ public class AuthOidcTest extends PersoniumTest {
     public final void  JWT形式の不正なIDTokenを指定し400エラーが返却されること()
             throws InterruptedException {
         String accountName = "invalidJWTIdTokenAccount";
+        String accountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         try {
             // テスト用のアカウントを作成
             // 他のテストと共用するAccountを使用すると、認証失敗のロックがかかり、テストが失敗する。このため、このテスト独自のAccountを作成する
             AccountUtils.createNonCredentialWithType(AbstractCase.MASTER_TOKEN_NAME,
-                    TEST_CELL1, accountName, "oidc:google", HttpStatus.SC_CREATED);
+                    TEST_CELL1, accountName, accountType, HttpStatus.SC_CREATED);
 
             Http.request("authn/oidc-auth.txt")
                     .with("remoteCell", TEST_CELL1)
@@ -138,11 +141,12 @@ public class AuthOidcTest extends PersoniumTest {
     public final void 有効期限切れのIDTokenを指定し400エラーが返却されること()
             throws InterruptedException {
         String accountName = "expiredIdTokenAccount";
+        String accountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         try {
             // テスト用のアカウントを作成
             // 他のテストと共用するAccountを使用すると、認証失敗のロックがかかり、テストが失敗する。このため、このテスト独自のAccountを作成する
             AccountUtils.createNonCredentialWithType(AbstractCase.MASTER_TOKEN_NAME,
-                    TEST_CELL1, accountName, "oidc:google", HttpStatus.SC_CREATED);
+                    TEST_CELL1, accountName, accountType, HttpStatus.SC_CREATED);
 
             Http.request("authn/oidc-auth.txt")
                     .with("remoteCell", TEST_CELL1)
@@ -162,11 +166,12 @@ public class AuthOidcTest extends PersoniumTest {
     public final void デコードできないJWT形式の不正なIDTokenを指定し400エラーが返却されること()
             throws InterruptedException {
         String accountName = "invalidIdTokenAccount";
+        String accountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         try {
             // テスト用のアカウントを作成
             // 他のテストと共用するAccountを使用すると、認証失敗のロックがかかり、テストが失敗する。このため、このテスト独自のAccountを作成する
             AccountUtils.createNonCredentialWithType(AbstractCase.MASTER_TOKEN_NAME,
-                    TEST_CELL1, accountName, "oidc:google", HttpStatus.SC_CREATED);
+                    TEST_CELL1, accountName, accountType, HttpStatus.SC_CREATED);
 
             Http.request("authn/oidc-auth.txt")
                     .with("remoteCell", TEST_CELL1)

--- a/src/test/java/io/personium/test/jersey/cell/ctl/AccountCreateTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/ctl/AccountCreateTest.java
@@ -37,6 +37,7 @@ import io.personium.test.categories.Unit;
 import io.personium.test.jersey.AbstractCase;
 import io.personium.test.jersey.ODataCommon;
 import io.personium.test.jersey.PersoniumRequest;
+import io.personium.test.jersey.plugin.AuthPluginForAuthTest;
 import io.personium.test.utils.AccountUtils;
 import io.personium.test.utils.Http;
 import io.personium.test.utils.TResponse;
@@ -264,12 +265,13 @@ public class AccountCreateTest extends ODataCommon {
     }
 
     /**
-     * Account新規登録時にPasswordなしでTypeに"oidc:google"を指定して登録できること.
+     * Accounts can be registered with accountType specified in loaded plugin and without password.
+     * (In test cases, AuthPluginForAuthTest is loaded by default.)
      */
     @Test
-    public final void Account新規登録時にPasswordなしでTypeにoidcコロンgoogleを指定して登録できること() {
+    public final void Accounts_can_be_registered_with_accountType_and_no_password() {
         String testAccountName = "personium.io@gmail.com";
-        String testAccountType = "oidc:google";
+        String testAccountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         String accLocHeader = null;
 
         try {
@@ -282,12 +284,13 @@ public class AccountCreateTest extends ODataCommon {
     }
 
     /**
-     * Account新規登録時にPasswordありでTypeに"oidc:google"を指定して登録できること.
+     * Accounts can be registered with accountType specified in loaded plugin and with password.
+     * (In test cases, AuthPluginForAuthTest is loaded by default.)
      */
     @Test
-    public final void Account新規登録時にPasswordありでTypeにoidcコロンgoogleを指定して登録できること() {
+    public final void Accounts_can_be_registered_with_accountType_and_password() {
         String testAccountName = "personium.io@gmail.com";
-        String testAccountType = "oidc:google";
+        String testAccountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         String testAccountPass = "password1234";
         String accLocHeader = null;
 
@@ -301,12 +304,13 @@ public class AccountCreateTest extends ODataCommon {
     }
 
     /**
-     * Account新規登録時にパスワードなしでTypeに"basic oidc:google"を指定して登録できること.
+     * Accounts can be registered with accountType `basic` and one specified in loaded plugin and without password.
+     * (In test cases, AuthPluginForAuthTest is loaded by default.)
      */
     @Test
-    public final void Account新規登録時にパスワードなしでTypeにbasicスペースoidcコロンgoogleを指定して登録できること() {
+    public final void Accouns_can_be_registered_with_basic_and_acountType_specified_in_plugin_without_password() {
         String testAccountName = "personium.io@gmail.com";
-        String testAccountType = "basic oidc:google";
+        String testAccountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         String accLocHeader = null;
 
         try {
@@ -319,12 +323,13 @@ public class AccountCreateTest extends ODataCommon {
     }
 
     /**
-     * Account新規登録時にパスワードありでTypeに"basic oidc:google"を指定して登録できること.
+     * Accounts can be registered with accountType `basic` and one specified in loaded plugin and with password.
+     * (In test cases, AuthPluginForAuthTest is loaded by default.)
      */
     @Test
-    public final void Account新規登録時にパスワードありでTypeにbasicスペースoidcコロンgoogleを指定して登録できること() {
+    public final void Accouns_can_be_registered_with_basic_and_acountType_specified_in_plugin_with_password() {
         String testAccountName = "personium.io@gmail.com";
-        String testAccountType = "basic oidc:google";
+        String testAccountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
         String testAccountPass = "password1234";
         String accLocHeader = null;
 
@@ -346,7 +351,7 @@ public class AccountCreateTest extends ODataCommon {
         invalidTypeStrings.add("Type=");
         invalidTypeStrings.add("");
         invalidTypeStrings.add("!aa");
-        invalidTypeStrings.add("basic  oidc:google");
+        invalidTypeStrings.add("basic  " + AuthPluginForAuthTest.ACCOUNT_TYPE);
         invalidTypeStrings.add("%E3%81%82");
         invalidTypeStrings.add("あ");
         invalidTypeStrings.add("       ");

--- a/src/test/java/io/personium/test/jersey/cell/ctl/AccountUpdateTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/ctl/AccountUpdateTest.java
@@ -40,6 +40,7 @@ import io.personium.test.categories.Unit;
 import io.personium.test.jersey.AbstractCase;
 import io.personium.test.jersey.ODataCommon;
 import io.personium.test.jersey.cell.auth.AuthTestCommon;
+import io.personium.test.jersey.plugin.AuthPluginForAuthTest;
 import io.personium.test.utils.AccountUtils;
 import io.personium.test.utils.Http;
 import io.personium.test.utils.TResponse;
@@ -435,7 +436,7 @@ public class AccountUpdateTest extends ODataCommon {
             // Set all properties and merge.
             JSONObject updateBody = new JSONObject();
             updateBody.put("Name", updateUserName);
-            updateBody.put("Type", "oidc:google");
+            updateBody.put("Type", AuthPluginForAuthTest.ACCOUNT_TYPE);
             updateBody.put("Status", Account.STATUS_DEACTIVATED);
             updateBody.put("IPAddressRange", "192.0.1.0");
             AccountUtils.mergeWithBody(AbstractCase.MASTER_TOKEN_NAME, cellName, updateUserName,
@@ -446,7 +447,7 @@ public class AccountUpdateTest extends ODataCommon {
             String type = getResponseResultParam(res, "Type");
             String status = getResponseResultParam(res, "Status");
             String ipAddressRange = getResponseResultParam(res, "IPAddressRange");
-            assertThat(type, is("oidc:google"));
+            assertThat(type, is(AuthPluginForAuthTest.ACCOUNT_TYPE));
             assertThat(status, is(Account.STATUS_DEACTIVATED));
             assertThat(ipAddressRange, is("192.0.1.0"));
 
@@ -460,7 +461,7 @@ public class AccountUpdateTest extends ODataCommon {
             type = getResponseResultParam(res, "Type");
             status = getResponseResultParam(res, "Status");
             ipAddressRange = getResponseResultParam(res, "IPAddressRange");
-            assertThat(type, is("oidc:google"));
+            assertThat(type, is(AuthPluginForAuthTest.ACCOUNT_TYPE));
             assertThat(status, is(Account.STATUS_DEACTIVATED));
             assertThat(ipAddressRange, is("192.0.1.0"));
 

--- a/src/test/java/io/personium/test/jersey/plugin/AuthPluginForAuthTest.java
+++ b/src/test/java/io/personium/test/jersey/plugin/AuthPluginForAuthTest.java
@@ -102,8 +102,8 @@ public class AuthPluginForAuthTest implements AuthPlugin {
         // verify
         if (CORRECTVALUE_STRING.equals(param)) {
             AuthenticatedIdentity ai = new AuthenticatedIdentity();
-            ai.setAccountName(ACCOUNT_TYPE);
-            ai.setAccountType(ACCOUNT_NAME);
+            ai.setAccountName(ACCOUNT_NAME);
+            ai.setAccountType(ACCOUNT_TYPE);
             return ai;
         } else if (WRONGVALUE_STRING.equals(param)) {
             throw OidcPluginException.AUTHN_FAILED.create();

--- a/src/test/java/io/personium/test/jersey/plugin/AuthPluginForAuthTest.java
+++ b/src/test/java/io/personium/test/jersey/plugin/AuthPluginForAuthTest.java
@@ -1,0 +1,114 @@
+/**
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.jersey.plugin;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
+import io.personium.plugin.auth.oidc.OidcPluginException;
+import io.personium.plugin.base.auth.AuthConst;
+import io.personium.plugin.base.auth.AuthPlugin;
+import io.personium.plugin.base.auth.AuthPluginException;
+import io.personium.plugin.base.auth.AuthenticatedIdentity;
+
+/**
+ * Dummy class for testing. This class authenticate user with dummy parameters.
+ */
+public class AuthPluginForAuthTest implements AuthPlugin {
+
+    /** Grant type which this class handles. */
+    public static final String GRANT_TYPE = "urn:x-personium:authtest";
+
+    /** Accout type which this class returns after authentication. */
+    public static final String ACCOUNT_TYPE = "accountTypeForTesting";
+
+    /** Key of parameter for authentication. */
+    public static final String KEY_PARAM = "test_param";
+
+    /** Parameter for authentication (correct pattern). */
+    public static final String CORRECTVALUE_STRING = "test_param_value";
+
+    /** Parameter for authentication (wrong pattern). */
+    public static final String WRONGVALUE_STRING = "test_param_value_wrong";
+
+    /** Account name which this class returns after authentication. */
+    public static final String ACCOUNT_NAME = "test_user_auth_plugin_for_auth_test";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getType() {
+        return AuthConst.PLUGIN_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getGrantType() {
+        return GRANT_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAccountType() {
+        return ACCOUNT_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticatedIdentity authenticate(Map<String, List<String>> body) throws AuthPluginException {
+        // TODO: refactoring not to use OidcPluginException
+
+        if (body == null) {
+            throw OidcPluginException.REQUIRED_PARAM_MISSING.create("Body");
+        }
+
+        List<String> params = body.get(KEY_PARAM);
+
+        if (params == null) {
+            // no param
+            throw OidcPluginException.REQUIRED_PARAM_MISSING.create(KEY_PARAM);
+        }
+
+        String param = params.get(0);
+
+        if (StringUtils.isEmpty(param)) {
+            throw OidcPluginException.REQUIRED_PARAM_MISSING.create(KEY_PARAM);
+        }
+
+        // verify
+        if (CORRECTVALUE_STRING.equals(param)) {
+            AuthenticatedIdentity ai = new AuthenticatedIdentity();
+            ai.setAccountName(ACCOUNT_TYPE);
+            ai.setAccountType(ACCOUNT_NAME);
+            return ai;
+        } else if (WRONGVALUE_STRING.equals(param)) {
+            throw OidcPluginException.AUTHN_FAILED.create();
+        } else {
+            throw OidcPluginException.INVALID_ID_TOKEN.create();
+        }
+    }
+}

--- a/src/test/java/io/personium/test/jersey/plugin/AuthPluginForAuthTest.java
+++ b/src/test/java/io/personium/test/jersey/plugin/AuthPluginForAuthTest.java
@@ -37,7 +37,7 @@ public class AuthPluginForAuthTest implements AuthPlugin {
     public static final String GRANT_TYPE = "urn:x-personium:authtest";
 
     /** Accout type which this class returns after authentication. */
-    public static final String ACCOUNT_TYPE = "accountTypeForTesting";
+    public static final String ACCOUNT_TYPE = "oidc:plugintest";
 
     /** Key of parameter for authentication. */
     public static final String KEY_PARAM = "test_param";

--- a/src/test/java/io/personium/test/jersey/plugin/PluginTest.java
+++ b/src/test/java/io/personium/test/jersey/plugin/PluginTest.java
@@ -17,16 +17,13 @@
  */
 package io.personium.test.jersey.plugin;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.http.HttpStatus;
 import org.junit.Test;
@@ -37,7 +34,6 @@ import io.personium.core.plugin.PluginInfo;
 import io.personium.core.plugin.PluginManager;
 import io.personium.core.rs.PersoniumCoreApplication;
 import io.personium.plugin.base.PluginException;
-import io.personium.plugin.base.auth.AuthConst;
 import io.personium.plugin.base.auth.AuthPlugin;
 import io.personium.plugin.base.auth.AuthenticatedIdentity;
 import io.personium.test.categories.Integration;
@@ -50,311 +46,154 @@ import io.personium.test.utils.AccountUtils;
 import io.personium.test.utils.Http;
 
 /**
- * Pluginクラスのテスト.
+ * Test for AuthPlugin class. This test tests only check if a plugin works correctly. As PluginsLoader loads AuthPlugin
+ * specified in properties as default, this test is executed while the dummy AuthPlugin (AuthPluginForTesting) is
+ * loaded.
  */
 @RunWith(PersoniumIntegTestRunner.class)
-@Category({Unit.class, Integration.class, Regression.class })
+@Category({Unit.class, Integration.class, Regression.class})
 public class PluginTest extends PersoniumTest {
     private String name;
 
-    /**
-     * idToken.
-     */
-    public static final String PROP_IDTOKEN = "id_token";
-
-    /**
-     * accountName.
-     */
-    public static final String PROP_ACCOUNT = "account";
-
-    /**
-     * properties file path.
-     */
-    public static final String OAUTH_PROPERTIES_FILE = "/src/test/resources/oauth/oauth.properties";
-
-    /** google oidc. **/
-    public static final String OIDC_GOOGLE = "oidc:google";
-    /** urn google grantType. **/
-    public static final String GOOGLE_GRANT_TYPE = "urn:x-personium:oidc:google";
-    /** マスタートークン(Bearer + MASTER_TOKEN_NAME). */
-    public static final String BEARER_MASTER_TOKEN = "Bearer " + AbstractCase.MASTER_TOKEN_NAME;
-
-    // google
-    static final String OIDC_PROVIDER_GOOGLE = "google";
     static final String TEST_CELL1 = "testcell1";
 
-    // 有効期限が切れているトー－クンの設定
-    static final String INVALID_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImF"
-     + "jYTJhZTQwZTA2NDY5YmQ0YjQ2NmI1MDI1MGVmNWE2MGM5OGU0ZTAifQ.eyJpc3Mi"
-     + "OiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJpYXQiOjE0ODQ3OTY1OTAs"
-     + "ImV4cCI6MTQ4NDgwMDE5MCwiYXRfaGFzaCI6IjV3alJTVGsxOVRSZ2d0MEduaTVC"
-     + "VFEiLCJhdWQiOiIxMDY5MTg5NzU1MjAzLWdoMnU1dnR1OGliZnJuM2pvbDAzcGh1"
-     + "ajMyaDZ0c2RnLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwic3ViIjoiMTE1"
-     + "MTg5NDkwNjc5NDIwMzU2MjA3IiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF6cCI6"
-     + "IjEwNjkxODk3NTUyMDMtZ2gydTV2dHU4aWJmcm4zam9sMDNwaHVqMzJoNnRzZGcu"
-     + "YXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJlbWFpbCI6InNvcmEyMzgzQGdt"
-     + "YWlsLmNvbSIsIm5hbWUiOiJmdW1peWFzdSBhYmUiLCJwaWN0dXJlIjoiaHR0cHM6"
-     + "Ly9saDYuZ29vZ2xldXNlcmNvbnRlbnQuY29tLy1veVZhMURwaDh2US9BQUFBQUFB"
-     + "QUFBSS9BQUFBQUFBQUFBQS9BS0JfVThzQUFBbGNZOVpISEFmeDNHOVJZbXJ4Rm1Z"
-     + "ajl3L3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJmdW1peWFzdSIsImZh"
-     + "bWlseV9uYW1lIjoiYWJlIiwibG9jYWxlIjoiamEifQ.fJ8pbTYFYhyQrYSvuob4W"
-     + "jIHu383KxpYkPuxlyxntYPvHIbftgoyGgA20Uq9xBXb6rBi6d8sEBSZTJEGyrExL"
-     + "N5dCILltbbvwgmolsR_z7TqTaGkNwpxcVYA4YaLltcvUwChQkklvjJYsQXrOi2Bq"
-     + "Kf3th-cSFGwssAh8-zLcJT8dgigNOaW9fG-Ppo8ty07DjKeQKkBy43usuyY8BpDS"
-     + "91yUwQ8d1DtMQ8XPjuAgbmOhIqE63RKHaLqF64G6i8cvKuYzYwruH1CIcBwluy87"
-     + "PLfRKGiMr8vRehW_PhPQo7uoXKmtEZrOK949KFbnGRujcS0qnPai45A45ZQ6wv2rg";
+    /**
+     * constructor.
+     */
+    public PluginTest() {
+        super(new PersoniumCoreApplication());
+    }
 
     /**
-      * コンストラクタ.
-      */
-     public PluginTest() {
-         super(new PersoniumCoreApplication());
-     }
-
-    /**
-     * プラグイン処理のgoogle認証を取得できること.
+     * Test if AuthPlugin loaded by PluginManager has authenticate function and it returns AuthenticatedIdentity when it
+     * is called.
      * @throws Exception .
      */
     @Test
-    public void プラグイン処理_一覧からgoogle認証プラグインを取得できること() throws Exception {
-        boolean bFind = false;
-        PluginManager pm = new PluginManager();
-        if (pm.size() > 0) {
-            PluginInfo pi = (PluginInfo) pm.getPluginsByGrantType(GOOGLE_GRANT_TYPE);
-            if (pi != null) {
-                bFind = true;
-                System.out.println("OK get grant_type = " + GOOGLE_GRANT_TYPE);
-            }
-            assertTrue(bFind);
-        }
-        // プラグインが存在しない場合にはエラーにしない
-        assertTrue(true);
-    }
+    public void AuthPlugin_loaded_by_PluginManager_has_authenticate_function_callable() throws Exception {
+        String account = AuthPluginForAuthTest.ACCOUNT_NAME;
+        String authParam = AuthPluginForAuthTest.CORRECTVALUE_STRING;
 
-    /**
-     * プラグイン処理の異常GrantTypeの場合にエラーとなること.
-     * @throws Exception .
-     */
-    @Test
-    public void プラグイン処理_異常GrantTypeの場合にエラーとなること() throws Exception {
-        String invalidGratType = "urn:x-dc1:oidc:hoge:code";
-
-        PluginManager pm = new PluginManager();
-        if (pm.size() > 0) {
-            PluginInfo pi = pm.getPluginsByGrantType(invalidGratType);
-
-            try {
-                AuthPlugin ap = (AuthPlugin) pi.getObj();
-                if (ap == null) {
-                    assertTrue(true);
-                }
-            } catch (Exception e) {
-                assertFalse(false);
-            }
-        } else {
-            // プラグインが存在しない場合にはエラーにしない
-            assertTrue(true);
-        }
-    }
-
-    /**
-     * プラグイン処理の認証一覧を取得できること.
-     * @throws Exception .
-     */
-    @Test
-    public void プラグイン処理_認証プラグイン一覧を取得できること() throws Exception {
-        boolean bFind = false;
-
-        // プラグインjarがディレクトリに存在する場合
-        PluginManager pm = new PluginManager();
-        if (pm.size() > 0) {
-            List<PluginInfo> pl = pm.getPluginsByType(AuthConst.PLUGIN_TYPE);
-            for (int i = 0; i < pl.size(); i++) {
-                PluginInfo pi = (PluginInfo) pl.get(i);
-                if (pi.getType().equals(AuthConst.PLUGIN_TYPE)) {
-                    bFind = true;
-                }
-            }
-            assertTrue(bFind);
-        } else {
-            // プラグインが存在しない場合にはエラーにしない
-            assertTrue(true);
-        }
-    }
-
-    /**
-     * GooglePlugin_アカウントとIdTokenを指定し認証プラグイン処理を直接実行できること.
-     * @throws Exception .
-     */
-    @Test
-    public void GooglePlugin_正常なアカウントとIdTokenを指定し認証プラグイン処理を直接実行できること() throws Exception {
-        PluginManager pm = new PluginManager();
-        if (pm.size() > 0) {
-            PluginInfo pi = pm.getPluginsByGrantType(GOOGLE_GRANT_TYPE);
-
-            // Map設定
-            Map<String, List<String>> body = new HashMap<String, List<String>>();
-
-            // idTokenの設定
-            Properties properties = getIdTokenProperty();
-            String idToken = properties.getProperty(PROP_IDTOKEN);
-            String account = properties.getProperty(PROP_ACCOUNT);
-
-            if (idToken != null && account != null) {
-                try {
-                    // Plugin
-                    body.put("id_token", Arrays.asList(idToken));
-                    AuthPlugin ap = (AuthPlugin) pi.getObj();
-                    AuthenticatedIdentity ai = ap.authenticate(body);
-
-                    // 実行結果
-                    if (ai != null) {
-                        String accountName = ai.getAccountName();
-                        if (accountName != null) {
-                            if (account.equals(accountName)) {
-                                String oidcType = ai.getAccountType();
-                                System.out.println(
-                                "OK authenticate account = " + accountName + " oidcType=" + oidcType);
-                            }
-                            assertTrue(true);
-                        }
-                    } else {
-                        System.out.println("NG authenticate");
-                        assertFalse(false);
-                    }
-                } catch (PluginException pe) {
-                    System.out.println(pe);
-                    assertFalse(true);
-                } catch (Exception e) {
-                    System.out.println(e);
-                    assertFalse(true);
-                }
-            }
-        } else {
-            assertFalse(true);
-        }
-    }
-
-    /**
-     * GooglePlugin_アカウントとIdTokenを設定し正常に認証され200が返却されること.
-     * @throws InterruptedException 待機失敗
-     */
-    @Test
-    public final void GooglePlugin_正常なアカウントとIdTokenを設定し認証され200が返却されること()
-            throws InterruptedException {
-
-        Properties properties = getIdTokenProperty();
-        String idToken = properties.getProperty(PROP_IDTOKEN);
-        String account = properties.getProperty(PROP_ACCOUNT);
-
-        if (idToken != null && account != null) {
-            try {
-                // テスト用のアカウントを作成
-                // 他のテストと共用するAccountを使用すると、認証失敗のロックがかかり、テストが失敗する。
-                // このため、このテスト独自のAccountを作成する
-                AccountUtils.createNonCredentialWithType(
-                        AbstractCase.MASTER_TOKEN_NAME,
-                        TEST_CELL1, account, OIDC_GOOGLE, HttpStatus.SC_CREATED);
-
-                Http.request("authn/plugin-oidc-auth.txt")
-                        .with("remoteCell", TEST_CELL1)
-                        .with("id_provider", OIDC_PROVIDER_GOOGLE)
-                        .with("id_token", idToken)
-                        .returns().statusCode(HttpStatus.SC_OK);
-
-            } finally {
-                AccountUtils.delete(TEST_CELL1,
-                        AbstractCase.MASTER_TOKEN_NAME,
-                        account, HttpStatus.SC_NO_CONTENT);
-            }
-        }
-    }
-
-    /**
-     * 異常な期限切れIDTokenを設定し400が返却されるこ.
-     * @throws InterruptedException 待機失敗
-     */
-    @Test
-    public final void GooglePlugin_異常な期限切れIDTokenを設定し400が返却されること()
-            throws InterruptedException {
-
-        Properties properties = getIdTokenProperty();
-        String idToken = properties.getProperty(PROP_IDTOKEN);
-        String account = properties.getProperty(PROP_ACCOUNT);
-
-        if (idToken != null && account != null) {
-            try {
-                // テスト用のアカウントを作成
-                // 他のテストと共用するAccountを使用すると、認証失敗のロックがかかり、テストが失敗する。
-                // このため、このテスト独自のAccountを作成する
-                AccountUtils.createNonCredentialWithType(
-                        AbstractCase.MASTER_TOKEN_NAME,
-                        TEST_CELL1, account, OIDC_GOOGLE, HttpStatus.SC_CREATED);
-
-                Http.request("authn/plugin-oidc-auth.txt")
-                        .with("remoteCell", TEST_CELL1)
-                        .with("id_provider", OIDC_PROVIDER_GOOGLE)
-                        .with("id_token", INVALID_TOKEN)
-                        .returns().statusCode(HttpStatus.SC_BAD_REQUEST);
-
-            } finally {
-                AccountUtils.delete(TEST_CELL1,
-                        AbstractCase.MASTER_TOKEN_NAME,
-                        account, HttpStatus.SC_NO_CONTENT);
-            }
-        }
-    }
-
-    /**
-     * 異常アカウントをCell設定しIDTokenは認証され異常値が返却されること.
-     * @throws InterruptedException 待機失敗
-     */
-    @Test
-    public final void GooglePlugin_異常アカウントをCell設定しIDTokenは認証され異常値が返却されること()
-            throws InterruptedException {
-
-        Properties properties = getIdTokenProperty();
-        String idToken = properties.getProperty(PROP_IDTOKEN);
-        String account = "hogehoge";
-
-        if (idToken != null && account != null) {
-            try {
-                AccountUtils.createNonCredentialWithType(
-                        AbstractCase.MASTER_TOKEN_NAME,
-                        TEST_CELL1, account, OIDC_GOOGLE, HttpStatus.SC_CREATED);
-
-                Http.request("authn/plugin-oidc-auth.txt")
-                        .with("remoteCell", TEST_CELL1)
-                        .with("id_provider", OIDC_PROVIDER_GOOGLE)
-                        .with("id_token", idToken)
-                        .returns().statusCode(HttpStatus.SC_BAD_REQUEST);
-
-            } finally {
-                AccountUtils.delete(TEST_CELL1,
-                        AbstractCase.MASTER_TOKEN_NAME,
-                        account, HttpStatus.SC_NO_CONTENT);
-            }
-        }
-    }
-
-    /**
-     * getProperty.
-     * @return properties
-     */
-    public static Properties getIdTokenProperty() {
-        Properties properties = new Properties();
-        String basepath = System.getProperty("user.dir");
-        String file = OAUTH_PROPERTIES_FILE;
         try {
-            InputStream inputStream = new FileInputStream(basepath + file);
-            properties.load(inputStream);
-            inputStream.close();
-        } catch (Exception ex) {
-            System.out.println(ex.getMessage());
+            PluginManager pm = new PluginManager();
+            if (pm.size() > 0) {
+                PluginInfo pi = pm.getPluginsByGrantType(AuthPluginForAuthTest.GRANT_TYPE);
+
+                // Authenticate paramaters
+                Map<String, List<String>> body = new HashMap<String, List<String>>();
+
+                body.put(AuthPluginForAuthTest.KEY_PARAM, Arrays.asList(authParam));
+                AuthPlugin ap = (AuthPlugin) pi.getObj();
+                AuthenticatedIdentity ai = ap.authenticate(body);
+
+                // Check if AuthenticatedIdentity is correct
+                if (ai != null) {
+                    String accountName = ai.getAccountName();
+                    if (accountName != null) {
+                        if (account.equals(accountName)) {
+                            String accountType = ai.getAccountType();
+                            System.out.println(
+                                    "OK authenticate account = " + accountName + " accountType=" + accountType);
+                        }
+                        assertEquals(account, accountName);
+                    }
+                } else {
+                    fail("No AuthenticatedIdentity is returned");
+                }
+            }
+        } catch (PluginException pe) {
+            fail(pe.getMessage());
+        } catch (Exception e) {
+            fail(e.getMessage());
         }
-        return properties;
     }
 
+    /**
+     * Return 200 when __token endpoint receives correct parameter.
+     * @throws InterruptedException Failed to wait
+     */
+    @Test
+    public final void Token_endpoint_with_plugin_returns_200_when_correct_param_is_requested()
+            throws InterruptedException {
+
+        String account = AuthPluginForAuthTest.ACCOUNT_NAME;
+        String accountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
+        String authParam = AuthPluginForAuthTest.CORRECTVALUE_STRING;
+
+        try {
+            // Creating account for testing.
+            // To avoid being locked by authentication failure, this test prepares
+            // another account only for this test.
+            AccountUtils.createNonCredentialWithType(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, account, accountType,
+                    HttpStatus.SC_CREATED);
+
+            Http.request("authn/plugin-auth.txt").with("remoteCell", TEST_CELL1)
+                    .with("grant_type", AuthPluginForAuthTest.GRANT_TYPE)
+                    .with("key_param", AuthPluginForAuthTest.KEY_PARAM).with("param", authParam).returns()
+                    .statusCode(HttpStatus.SC_OK);
+
+        } finally {
+            AccountUtils.delete(TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, account, HttpStatus.SC_NO_CONTENT);
+        }
+    }
+
+    /**
+     * Return 400 when __token endpoint receives wrong parameter.
+     * @throws InterruptedException Failed to wait
+     */
+    @Test
+    public final void Token_endpoint_with_plugin_returns_400_when_wrong_param_is_requested()
+            throws InterruptedException {
+
+        String account = AuthPluginForAuthTest.ACCOUNT_NAME;
+        String accountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
+        String authParam = AuthPluginForAuthTest.WRONGVALUE_STRING;
+
+        try {
+            // Creating account for testing.
+            // To avoid being locked by authentication failure, this test prepares
+            // another account only for this test.
+            AccountUtils.createNonCredentialWithType(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, account, accountType,
+                    HttpStatus.SC_CREATED);
+
+            Http.request("authn/plugin-auth.txt").with("remoteCell", TEST_CELL1)
+                    .with("grant_type", AuthPluginForAuthTest.GRANT_TYPE)
+                    .with("key_param", AuthPluginForAuthTest.KEY_PARAM).with("param", authParam).returns()
+                    .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        } finally {
+            AccountUtils.delete(TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, account, HttpStatus.SC_NO_CONTENT);
+        }
+    }
+
+    /**
+     * Return 400 when the cell does not contain an account specified in AuthenticatedIdentity.
+     * @throws InterruptedException Failed to wait
+     */
+    @Test
+    public final void Token_endpoint_with_plugin_returns_400_when_no_account_matched() throws InterruptedException {
+
+        String account = "hogehoge";
+        String accountType = AuthPluginForAuthTest.ACCOUNT_TYPE;
+        String authParam = AuthPluginForAuthTest.WRONGVALUE_STRING;
+
+        try {
+            AccountUtils.createNonCredentialWithType(AbstractCase.MASTER_TOKEN_NAME, TEST_CELL1, account, accountType,
+                    HttpStatus.SC_CREATED);
+
+            Http.request("authn/plugin-auth.txt").with("remoteCell", TEST_CELL1)
+                    .with("grant_type", AuthPluginForAuthTest.GRANT_TYPE)
+                    .with("key_param", AuthPluginForAuthTest.KEY_PARAM).with("param", authParam).returns()
+                    .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        } finally {
+            AccountUtils.delete(TEST_CELL1, AbstractCase.MASTER_TOKEN_NAME, account, HttpStatus.SC_NO_CONTENT);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String toString() {
         return "Plugin => Name:" + name + "\n";

--- a/src/test/resources/personium-log-level.properties
+++ b/src/test/resources/personium-log-level.properties
@@ -1,0 +1,86 @@
+#
+# personium.io
+# Copyright 2014-2020 Personium Project Authors
+# - FUJITSU LIMITED
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# If not specified in this file, log level is determined in the following manners.
+#   4xx errors : INFO level.
+#   5xx errors : WARN level.
+#   otherwise  : WARN level.
+# ex)
+#io.personium.core.loglevel.PR400-OD-0001=info
+
+## PR
+io.personium.core.loglevel.PR500-SV-0005=error
+io.personium.core.loglevel.PR500-SV-0006=error
+io.personium.core.loglevel.PR503-SV-0003=info
+
+## PL
+# Server
+io.personium.core.loglevel.PL-SV-0001=error
+io.personium.core.loglevel.PL-SV-0002=error
+io.personium.core.loglevel.PL-SV-0003=error
+io.personium.core.loglevel.PL-SV-0009=error
+io.personium.core.loglevel.PL-SV-0013=error
+io.personium.core.loglevel.PL-SV-0014=info
+io.personium.core.loglevel.PL-SV-0015=error
+io.personium.core.loglevel.PL-SV-0016=info
+io.personium.core.loglevel.PL-SV-0018=info
+io.personium.core.loglevel.PL-SV-0019=error
+io.personium.core.loglevel.PL-SV-0020=error
+io.personium.core.loglevel.PL-SV-0022=debug
+
+# Dav
+io.personium.core.loglevel.PL-DV-0001=info
+io.personium.core.loglevel.PL-DV-0002=info
+io.personium.core.loglevel.PL-DV-0005=debug
+io.personium.core.loglevel.PL-DV-0006=debug
+io.personium.core.loglevel.PR503-DV-0001=info
+
+# Auth
+io.personium.core.loglevel.PL-AU-0001=info
+io.personium.core.loglevel.PL-AU-0002=info
+io.personium.core.loglevel.PL-AU-0004=info
+
+# Authn
+io.personium.core.loglevel.PL-AN-0001=info
+io.personium.core.loglevel.PL-AN-0002=info
+io.personium.core.loglevel.PL-AN-0003=info
+io.personium.core.loglevel.PL-AN-0004=info
+io.personium.core.loglevel.PL-AN-0005=info
+
+# OIDC
+io.personium.core.loglevel.PL-OI-0001=info
+io.personium.core.loglevel.PL-OI-0002=info
+io.personium.core.loglevel.PL-OI-0003=info
+io.personium.core.loglevel.PL-OI-0004=info
+
+# ServiceCollection
+io.personium.core.loglevel.PL-SC-0001=info
+io.personium.core.loglevel.PL-SC-0002=info
+
+# Elastic Search
+io.personium.core.loglevel.PL-ES-0001=info
+io.personium.core.loglevel.PL-ES-0002=debug
+io.personium.core.loglevel.PL-ES-0003=info
+io.personium.core.loglevel.PL-ES-0004=info
+io.personium.core.loglevel.PL-ES-0005=debug
+
+# Misc
+io.personium.core.loglevel.PR501-MC-0001=info
+io.personium.core.loglevel.PR501-MC-0002=info
+io.personium.core.loglevel.PR503-SV-0001=info
+io.personium.core.loglevel.PR503-SV-0005=info

--- a/src/test/resources/personium-messages.properties
+++ b/src/test/resources/personium-messages.properties
@@ -1,0 +1,481 @@
+#
+# Personium
+# Copyright 2014-2020 Personium Project Authors
+# - FUJITSU LIMITED
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+### ResponseMessages
+## ODATA
+# PR400-OD
+io.personium.core.msg.PR400-OD-0001=JSON parse error.
+io.personium.core.msg.PR400-OD-0002=OData Query parse error.
+io.personium.core.msg.PR400-OD-0003=OData $filter Parse Error.
+io.personium.core.msg.PR400-OD-0004=OData EntityKey Parse error.
+io.personium.core.msg.PR400-OD-0005=$format value [{0}] is invalid.
+io.personium.core.msg.PR400-OD-0006=request body format error. field [{0}]
+io.personium.core.msg.PR400-OD-0007=[{0}]
+io.personium.core.msg.PR400-OD-0008=No such association.
+io.personium.core.msg.PR400-OD-0009=[{0}] is required.
+io.personium.core.msg.PR400-OD-0010=Key for Navigation Property should not be specified in $links POST.
+io.personium.core.msg.PR400-OD-0011=Key for Navigation Property should be specified in $links.
+io.personium.core.msg.PR400-OD-0012=Specifying the type of [{0}] is invalid.
+io.personium.core.msg.PR400-OD-0013=$inlinecount value [{0}] is invalid.
+io.personium.core.msg.PR400-OD-0014=Unknown property was appointed.
+io.personium.core.msg.PR400-OD-0015=Odata $orderby parse error.
+io.personium.core.msg.PR400-OD-0016=Single key should not be null.
+io.personium.core.msg.PR400-OD-0017=OData $select Parse error.
+io.personium.core.msg.PR400-OD-0018=Number of properties exceeds the limit [{0}].
+io.personium.core.msg.PR400-OD-0019=AssociationEnd do not put request.
+io.personium.core.msg.PR400-OD-0020=Schema mismatch.
+io.personium.core.msg.PR400-OD-0021=$batch body format is invalid. Request header format is invalid [{0}].
+io.personium.core.msg.PR400-OD-0022=$batch body format is invalid. Changeset should not have other changeset.
+io.personium.core.msg.PR400-OD-0023=$batch body parse error.
+io.personium.core.msg.PR400-OD-0024=[{0}] does not exist.
+io.personium.core.msg.PR400-OD-0025=[{0}] does not exist.
+io.personium.core.msg.PR400-OD-0026=OData $expand parse error.
+io.personium.core.msg.PR400-OD-0027=The index definition of another type already exists.
+io.personium.core.msg.PR400-OD-0028=OData EntityKey for $links parse error.
+io.personium.core.msg.PR400-OD-0029=Query value [{0}]=[{1}] is invalid.
+io.personium.core.msg.PR400-OD-0030=$batch body format is invalid. Too many requests. [{0}]
+io.personium.core.msg.PR400-OD-0031=Cannot create $links because multiplicity is [1:1].
+io.personium.core.msg.PR400-OD-0032=EntityType structure hierarchy exceeds the limit or number of properties exceeds the limit.
+io.personium.core.msg.PR400-OD-0033=EntityType count exceeds the limit.
+io.personium.core.msg.PR400-OD-0034=$batch body format is invalid. Request path format is invalid [{0}].
+io.personium.core.msg.PR400-OD-0035=$batch body format is invalid. Request Method not allowed [{0}].
+io.personium.core.msg.PR400-OD-0036=OData Query [{0}] parse error.
+io.personium.core.msg.PR400-OD-0037=Total of the specified value of $top exceeds the limit.
+io.personium.core.msg.PR400-OD-0038=$links count exceeds the limit.
+io.personium.core.msg.PR400-OD-0039=Total of the specified value of $expand exceeds the limit.
+io.personium.core.msg.PR400-OD-0040=Cannot specify the list type to $orderby.
+io.personium.core.msg.PR400-OD-0041=Request header {0} value is invalid [{1}].
+io.personium.core.msg.PR400-OD-0042=Operation is not supported: {0}
+io.personium.core.msg.PR400-OD-0043=Unsupported operator specified in query.
+io.personium.core.msg.PR400-OD-0044=Unsupported function specified in query.
+io.personium.core.msg.PR400-OD-0045=An unknown property with name ''{0}'' was found.
+io.personium.core.msg.PR400-OD-0046=Mismatched operand/argument is specified for ''{0}''.
+io.personium.core.msg.PR400-OD-0047=Operand or argument for ''{0}'' has unsupported/invalid format.
+io.personium.core.msg.PR400-OD-0048=Unable to parse operand or argument. ''{0}''
+io.personium.core.msg.PR400-OD-0049=[{0}] field format error. Cell URL should be normalized URL with http(s) scheme and trailing slash.
+io.personium.core.msg.PR400-OD-0050=[{0}] field format error. Schema URI should be either normalized URL with http(s) scheme and trailing slash, or URN.
+io.personium.core.msg.PR400-OD-0051=Query value is invalid.
+# PR404-OD
+io.personium.core.msg.PR404-OD-0000=Not found.
+io.personium.core.msg.PR404-OD-0001=No such entity set.
+io.personium.core.msg.PR404-OD-0002=No such entity.
+io.personium.core.msg.PR404-OD-0003=No such Navigation Property.
+# PR409-OD
+io.personium.core.msg.PR409-OD-0001=This entity has related data.
+io.personium.core.msg.PR409-OD-0002=Links exists already.
+io.personium.core.msg.PR409-OD-0003=The entity already exists.
+io.personium.core.msg.PR409-OD-0004=The entity already exists. [{0}]
+io.personium.core.msg.PR409-OD-0005=The entity already exists. [{0}]
+io.personium.core.msg.PR409-OD-0006=Relation between EntityTypes already exists.
+# PR412-OD
+io.personium.core.msg.PR412-OD-0001=If-Match header is required.
+io.personium.core.msg.PR412-OD-0002=ETag does not match.
+io.personium.core.msg.PR412-OD-0003=Conflict.
+
+# PR415-OD
+io.personium.core.msg.PR415-OD-0001=Unsupported media type:[{0}].
+
+# PR500-OD
+io.personium.core.msg.PR500-OD-0001=Detected a duplicate of the property name:[{0}].
+io.personium.core.msg.PR500-OD-0002=Internal data inconsistency detected.
+
+## DAV
+# PR400-DV
+io.personium.core.msg.PR400-DV-0001=XML parse error.
+io.personium.core.msg.PR400-DV-0002=XML content error.
+io.personium.core.msg.PR400-DV-0003=Invalid depth header value:[{0}].
+io.personium.core.msg.PR400-DV-0004=Role not found.
+io.personium.core.msg.PR400-DV-0005=Box not found url:[{0}].
+io.personium.core.msg.PR400-DV-0006=XML validate error. Cause:[{0}].
+io.personium.core.msg.PR400-DV-0007=Cannot add any more child resources.
+io.personium.core.msg.PR400-DV-0008=Hierarchy of the collection is too deep.
+io.personium.core.msg.PR400-DV-0009=Request header {0} value is invalid [{1}].
+io.personium.core.msg.PR400-DV-0010=Header {0} is required.
+io.personium.core.msg.PR400-DV-0011=Prohibited to move service source collection.
+io.personium.core.msg.PR400-DV-0012=Prohibited to overwrite collection resource.
+io.personium.core.msg.PR400-DV-0013=Prohibited to move resource to OData collection.
+io.personium.core.msg.PR400-DV-0014=Prohibited to move resource to file.
+io.personium.core.msg.PR400-DV-0015=Prohibited to move box.
+io.personium.core.msg.PR400-DV-0016=Prohibited to move resource to service collection.
+io.personium.core.msg.PR400-DV-0017=Prohibited to overwrite service source collection.
+io.personium.core.msg.PR400-DV-0018=Prohibited to create collection under service source collection.
+
+# PR404-DV
+io.personium.core.msg.PR404-DV-0001=Resource not found. [{0}].
+io.personium.core.msg.PR404-DV-0002=Box not found at [{0}].
+io.personium.core.msg.PR404-DV-0003=Cell not found.
+
+# PR405-DV
+io.personium.core.msg.PR405-DV-0001=Method not allowed. MKCOL can only be executed on a deleted/non-existent resource.
+
+# PR403-DV
+io.personium.core.msg.PR403-DV-0001=Infinite depth is not supported.
+io.personium.core.msg.PR403-DV-0003=Cannot delete collection if it has any child resources.
+io.personium.core.msg.PR403-DV-0004=Resource name is invalid [{0}].
+io.personium.core.msg.PR403-DV-0005=Destination header value [{0}] equals request URL.
+
+# PR409-DV
+io.personium.core.msg.PR409-DV-0001=intermediate collection [{0}] should be created first.
+io.personium.core.msg.PR409-DV-0002=File [{0}] already exists.
+
+# PR412-DV
+io.personium.core.msg.PR412-DV-0001=ETag does not match.
+io.personium.core.msg.PR412-DV-0002=Overwrite header is "F" and the destination URL is already mapped to a resource.
+
+# PR416-DV
+io.personium.core.msg.PR416-DV-0001=Requested range not satisfiable.
+# PR500-DV
+io.personium.core.msg.PR500-DV-0001=File system inconsistency detected.
+io.personium.core.msg.PR500-DV-0002=Dav system inconsistency detected.
+# PR503-DV
+io.personium.core.msg.PR503-DV-0001=Failed to access the target resource due to concurrent update/delete operation by another process.
+
+## ServiceCollection
+# PR500-SC
+io.personium.core.msg.PR500-SC-0001=Engine connection error.
+io.personium.core.msg.PR500-SC-0002=File open error.
+io.personium.core.msg.PR500-SC-0003=File close error.
+io.personium.core.msg.PR500-SC-0004=IO error.
+io.personium.core.msg.PR500-SC-0005=Unknown error at Engine.
+io.personium.core.msg.PR500-SC-0006=Invalid HTTP response was returned from a service.
+
+## SentMessage
+io.personium.core.msg.PR400-SM-0001=ToRelation [{0}] does not exist.
+io.personium.core.msg.PR400-SM-0002=ToRelation [{0}] does not have related ExtCell.
+io.personium.core.msg.PR400-SM-0003=The maximum number of destinations was exceeded.
+io.personium.core.msg.PR400-SM-0004=Box corresponding to the schema can not be found from the schema-authenticated token. Schema[{0}].
+# PR500-SM
+io.personium.core.msg.PR500-SM-0001=Sent Message connection error.
+io.personium.core.msg.PR500-SM-0002=Sent Message body parse error.
+
+## ReceivedMessage
+io.personium.core.msg.PR400-RM-0001=Requested relation already exists.
+io.personium.core.msg.PR400-RM-0002=Box corresponding to the schema can not be found. Schema [{0}].
+io.personium.core.msg.PR400-RM-0003=Box corresponding to the RelationClassURL can not be found. RelationClassURL [{0}].
+# io.personium.core.msg.PR409-RM-0001=Requested relation URL parse error.
+io.personium.core.msg.PR409-RM-0002=Requested relation does not exists. Type [{0}]. Keys [{1}].
+# io.personium.core.msg.PR409-RM-0003=Requested relation target URL parse error.
+io.personium.core.msg.PR409-RM-0004=Request relation target does not exist. Type [{0}]. Keys [{1}].
+io.personium.core.msg.PR409-RM-0005=RequestRelation and RequestRelationTarget is not related. [Type [{0}]. Keys[{1}]] - [Type {2}. Keys[{3}]].
+
+## Auth
+# PR400-AU
+io.personium.core.msg.PR400-AU-0001=Password format is invalid.
+io.personium.core.msg.PR400-AU-0002=Request parameter is invalid [{0}].
+io.personium.core.msg.PR400-AU-0003=Personium credential required.
+io.personium.core.msg.PR400-AN-0004=Unsupported hash algorithm.
+
+# PR401-AU
+io.personium.core.msg.PR401-AU-0001=Authorization required.
+io.personium.core.msg.PR401-AU-0002=Access token expired.
+io.personium.core.msg.PR401-AU-0003=Invalid authentication scheme.
+io.personium.core.msg.PR401-AU-0004=Basic auth format error.
+io.personium.core.msg.PR401-AU-0005=Authentication failed.
+io.personium.core.msg.PR401-AU-0006=Token parse error.
+io.personium.core.msg.PR401-AU-0007=Can not access with refresh token.
+io.personium.core.msg.PR401-AU-0008=Token dsig error.
+io.personium.core.msg.PR401-AU-0009=Authentication failed.
+io.personium.core.msg.PR401-AU-0010=Authentication failed.
+io.personium.core.msg.PR401-AU-0011=Authentication failed.
+io.personium.core.msg.PR401-AU-0012=Can not access with password change access token.
+
+# PR403-AU
+io.personium.core.msg.PR403-AU-0001=Unit user access required.
+io.personium.core.msg.PR403-AU-0002=Necessary privilege is lacking.
+io.personium.core.msg.PR403-AU-0003=This resource can not be accessed by the Unit User specified in authorization header.
+io.personium.core.msg.PR403-AU-0004=Schema authentication is required to access this resource.
+io.personium.core.msg.PR403-AU-0005=This resource can not be accessed with the schema that has been authenticated.
+io.personium.core.msg.PR403-AU-0006=Insufficient schema authorization level.
+io.personium.core.msg.PR403-AU-0007=Insufficient scope is granted for the access token. [{0}] Privilege is required.
+
+## Authn
+# PR400-AN
+io.personium.core.msg.PR400-AN-0001=Unsupported grant type. [{0}]
+io.personium.core.msg.PR400-AN-0002=Invalid p_target.
+
+# client authn error
+io.personium.core.msg.PR400-AN-0003=Failed to parse client assertion.
+io.personium.core.msg.PR400-AN-0004=Client secret is expired and invalid.
+io.personium.core.msg.PR400-AN-0005=Client secret dsig is invalid.
+io.personium.core.msg.PR400-AN-0006=Client secret issuer does not match the client_id.
+io.personium.core.msg.PR400-AN-0007=Client secret target is wrong.
+
+io.personium.core.msg.PR400-AN-0008=Trans-Cell access can not represent owner.
+io.personium.core.msg.PR400-AN-0009=Token parse error.
+io.personium.core.msg.PR400-AN-0010=Token expired or invalid.
+io.personium.core.msg.PR400-AN-0011=Token dsig is invalid.
+io.personium.core.msg.PR400-AN-0012=Token target is wrong. target=[{0}]
+
+io.personium.core.msg.PR400-AN-0013=Not a refresh token.
+
+io.personium.core.msg.PR400-AN-0014=Not allowed to represent owner.
+io.personium.core.msg.PR400-AN-0015=Cell owner does not exist.
+
+io.personium.core.msg.PR400-AN-0016=Required parameter [{0}] missing.
+io.personium.core.msg.PR400-AN-0017=Authentication failed.
+
+io.personium.core.msg.PR400-AN-0018=Authorization header is invalid.
+io.personium.core.msg.PR400-AN-0019=Invalid grant code.
+io.personium.core.msg.PR401-AN-0020=Client mismatch. [{0}] expected, but was [{1}].
+io.personium.core.msg.PR401-AN-0021=Client Authentication is required.
+io.personium.core.msg.PR400-AN-0022=Invalid Client Assertion Type. Acceptable Value is [{0}].
+
+io.personium.core.msg.PR401-AN-0023=The password should be changed.
+
+## Authz
+io.personium.core.msg.PR400-AZ-0001=Unsupported response_type.
+io.personium.core.msg.PR400-AZ-0002=Request parameter is invalid [client_id].
+io.personium.core.msg.PR400-AZ-0003=Request parameter is invalid [redirect_uri].
+io.personium.core.msg.PR400-AZ-0004=Request parameter is invalid [response_type].
+io.personium.core.msg.PR400-AZ-0005=JSON parse error. {0}
+io.personium.core.msg.PR400-AZ-0006=ID Token encoded invalid. {0}
+io.personium.core.msg.PR400-AZ-0007=Authorization failed.
+io.personium.core.msg.PR400-AZ-0008=Request parameter is invalid [expires_in].
+io.personium.core.msg.PR401-AZ-0001=User cancel.
+io.personium.core.msg.PR401-AZ-0002=Token authorization error.
+
+# PR500-AU
+io.personium.core.msg.PR500-AN-0001=Root ca certificate setting error.
+
+## Event
+# PR400-EV
+io.personium.core.msg.PR400-EV-0001=JSON parse error.
+io.personium.core.msg.PR400-EV-0002=Request header is invalid [X-Personium-RequestKey].
+io.personium.core.msg.PR400-EV-0003=[{0}] is required.
+io.personium.core.msg.PR400-EV-0004=[{0}] field format error.
+io.personium.core.msg.PR400-EV-0005=Cannot delete current eventLog file.
+
+# PR500-EV
+io.personium.core.msg.PR500-EV-0001=Failed to output http response.
+io.personium.core.msg.PR500-EV-0002=Cannot open archive eventLog file.
+io.personium.core.msg.PR500-EV-0003=Delete eventLog failed.
+
+## Bar file export/import API
+## Http response message(CSV): "message-id","message","time-stamp(YYYY-MM-DDThh:mm:ss.sssZ)"
+io.personium.core.msg.PL-BI-0000=Bar installation completed.
+io.personium.core.msg.PL-BI-0001=Bar installation failed({0}).
+io.personium.core.msg.PL-BI-1000=Bar installation started.
+io.personium.core.msg.PL-BI-1001=Installation started.
+io.personium.core.msg.PL-BI-1002=Installation processing.
+io.personium.core.msg.PL-BI-1003=Installation completed.
+io.personium.core.msg.PL-BI-1004=Installation failed({0}).
+io.personium.core.msg.PL-BI-1005=Unknown error({0}).
+
+io.personium.core.msg.PL-BI-2000=Failed to read request body.
+io.personium.core.msg.PL-BI-2001=Invalid structure of bar file or empty.
+io.personium.core.msg.PL-BI-2002=JSON/XML parse error.
+io.personium.core.msg.PL-BI-2003=JSON/XML data definition error.
+io.personium.core.msg.PL-BI-2004=WebDAV file registration error.
+io.personium.core.msg.PL-BI-2005=WebDAV file registration error. Invalid Content-Type.
+io.personium.core.msg.PL-BI-2006=Entry is not contained in 90_rootprops.xml.
+io.personium.core.msg.PL-BI-2007=ACL namespace is not role class URL.
+io.personium.core.msg.PL-BI-2008=href tag does not exist.
+io.personium.core.msg.PL-BI-2009=href element value is empty.
+io.personium.core.msg.PL-BI-2010=href element value does not start with '{0}': {1}
+io.personium.core.msg.PL-BI-2011=Duplicated paths are detected in href elements: {0}
+io.personium.core.msg.PL-BI-2012=Collection path is not defined: {0}
+io.personium.core.msg.PL-BI-2013=Another resource exists under the OData collection: {0}
+io.personium.core.msg.PL-BI-2014=Another resource exists under the Service collection: {0}
+io.personium.core.msg.PL-BI-2015=Another resource exists under the WebDAV File: {0}
+io.personium.core.msg.PL-BI-2016=Service collection must contain '__src' collection: {0}
+io.personium.core.msg.PL-BI-2017=Resource name is invalid: {0}
+io.personium.core.msg.PL-BI-2018=Unexpected tag: {0}
+
+## Bar file Install
+# PR400-BI
+io.personium.core.msg.PR400-BI-0001=Request header is not defined or invalid [{0}].
+io.personium.core.msg.PR400-BI-0002=Bar file size too large [{0}B].
+io.personium.core.msg.PR400-BI-0003=Bar file entry size too large [{0}, {1}B].
+io.personium.core.msg.PR400-BI-0004=Install target box is already registered as Box Schema[{0}].
+io.personium.core.msg.PR400-BI-0005=Bar file size invalid[{0}, {1}B].
+io.personium.core.msg.PR400-BI-0006=[{0}] file format error.
+io.personium.core.msg.PR400-BI-0007=Cannot open bar file [{0}].
+io.personium.core.msg.PR400-BI-0008=Cannot read bar file [{0}].
+io.personium.core.msg.PR400-BI-0009=Invalid bar file structures [{0}].
+io.personium.core.msg.PR400-BI-0010=Bar file structure and bar_version do not match.
+
+# PR405-BI
+io.personium.core.msg.PR405-BI-0001=Install target box is already registered [{0}].
+
+# PR500-BI
+io.personium.core.msg.PR500-BI-0001=Failed to output http response.
+
+
+## Server
+# PR500-SV
+io.personium.core.msg.PR500-SV-0000=Unknown error.
+io.personium.core.msg.PR500-SV-0001=Datastore connection error.
+io.personium.core.msg.PR500-SV-0002=Datastore unknown error.
+io.personium.core.msg.PR500-SV-0003=Elasticsearch request retry over [{0}].
+io.personium.core.msg.PR500-SV-0004=File system access error [{0}].
+io.personium.core.msg.PR500-SV-0005=Failed to search from datastore.
+io.personium.core.msg.PR500-SV-0006=Failed to update data store, and failed to rollback.
+io.personium.core.msg.PR500-SV-0007=Failed to update data store, and completed to rollback.
+
+# PR503-SV
+io.personium.core.msg.PR503-SV-0001=Too many concurrent requests.
+io.personium.core.msg.PR503-SV-0002=Server connection error.
+io.personium.core.msg.PR503-SV-0003=Server error. (Lock Manager) Data lock state unknown.
+io.personium.core.msg.PR503-SV-0004=Service is under maintenance [restoring].
+io.personium.core.msg.PR503-SV-0005=Operation is prohibited as one or more disks are almost full.
+io.personium.core.msg.PR503-SV-0006=Server connection error. (Datastore)
+
+## NetWork
+io.personium.core.msg.PR500-NW-0000=Network error. {0}
+io.personium.core.msg.PR500-NW-0001=HTTP {0} request to {1} failed. Response code : {2}.
+io.personium.core.msg.PR500-NW-0002=Unexpected response from {0}, where {1} expected.
+io.personium.core.msg.PR500-NW-0003=Unexpected value from key={0}, where "{1}" value expected.
+
+## UI
+io.personium.core.msg.PR412-UI-0001=Property [{0}] not configured.
+io.personium.core.msg.PR412-UI-0002=Property settings error. [{0}] should be normalized URL with http(s), personium-localunit and personium-localcell scheme.
+io.personium.core.msg.PR412-UI-0003=Property settings error. [{0}]
+io.personium.core.msg.PR500-UI-0001=Invalid HTTP response was returned from {0}.
+io.personium.core.msg.PR500-UI-0002=Could not connect to {0}.
+
+## Misc
+# PR405-MC
+io.personium.core.msg.PR400-MC-0001=[{0}] does not exist in the snapshot file.
+io.personium.core.msg.PR400-MC-0002=Path based CellUrl access is not allowed.
+io.personium.core.msg.PR400-MC-0003=Version of the snapshot file is invalid. Expected [{0}] but was [{1}].
+io.personium.core.msg.PR400-MC-0004=The specified snapshot file is not zip file.
+io.personium.core.msg.PR404-MC-0001=URI is not recognized.
+io.personium.core.msg.PR405-MC-0001=Method not allowed.
+io.personium.core.msg.PR408-MC-0001=Request timeout in server.
+io.personium.core.msg.PR409-MC-0001=Cell to be processed is being accessed by other requests.
+io.personium.core.msg.PR409-MC-0002=Currently importing snapshot onto the original cell where the snapshot is exported is allowed. And, importing snapshot onto another cell is only allowed when the original cell no longer exists.
+io.personium.core.msg.PR412-MC-0001=Precondition failed [Header: {0}].
+io.personium.core.msg.PR415-MC-0001=Unsupported media type.
+# PR501-MC
+io.personium.core.msg.PR501-MC-0001=Method not implemented.
+io.personium.core.msg.PR501-MC-0002=Not implemented. [{0}].
+
+## Common
+io.personium.core.msg.PR400-CM-0001=Required key [{0}] missing.
+io.personium.core.msg.PR400-CM-0002=Field [{0}] format error. Must be [{1}].
+io.personium.core.msg.PR400-CM-0003=Unknown key [{0}] specified.
+io.personium.core.msg.PR400-CM-0004=JSON parse error. [{0}].
+io.personium.core.msg.PR400-CM-0005=Invalid URL authority [{0}]. This unit is configured for URL authority [{1}]
+
+io.personium.core.msg.PR409-CM-0001=Cell status is [import failed]. Only Unit Level's APIs, CellImport and GetToken are executable.
+io.personium.core.msg.PR409-CM-0002=Because [{0}] is being executed, writing to cell can not be done.
+
+io.personium.core.msg.PR500-CM-0001=Failed to load the request body for some reason.
+io.personium.core.msg.PR500-CM-0002=Files I/O error caused [{0}] to fail.
+io.personium.core.msg.PR500-CM-0003=Invalid URL [{0}] is used internally.
+
+## Plug-in
+# PR500-PL
+io.personium.core.msg.PR500-PL-0001=Unchecked exception not caught inside the plug-in.
+# AuthPluginException
+io.personium.core.msg.PR400-PA-0001=AuthPlugin authentication failed. [{0}].
+io.personium.core.msg.PR401-PA-0001=AuthPlugin authentication failed. [{0}].
+io.personium.core.msg.PR500-PA-0001=AuthPlugin authentication error. [{0}].
+io.personium.core.msg.PR503-PA-0001=AuthPlugin authentication error. [{0}].
+
+### PL LogMessage
+## ODATA
+io.personium.core.msg.PL-OD-0001=multiple records ({0}) found for the key.
+io.personium.core.msg.PL-OD-0002=Failed to bulk insert.
+io.personium.core.msg.PL-OD-0003=Duplicated property names are detected:[{0}][{1}].
+
+## DAV
+io.personium.core.msg.PL-DV-0001=Role not found at [{0}].
+io.personium.core.msg.PL-DV-0002=Requested range not satisfiable at [{0}].
+io.personium.core.msg.PL-DV-0003=Dav file too short at [{0}.size={1},range={2}].
+io.personium.core.msg.PL-DV-0004=Failed to delete binary data. id={0}
+io.personium.core.msg.PL-DV-0005=Start file operation. [path={0}]
+io.personium.core.msg.PL-DV-0006=End file operation. [time=%timems, size={0}KB]
+
+## Server
+io.personium.core.msg.PL-SV-0001=Authentic Data Store Entity Create Fail. Message={0}
+io.personium.core.msg.PL-SV-0002=Authentic Data Store Entity Update Fail. Message={0}
+io.personium.core.msg.PL-SV-0003=Authentic Data Store Entity Delete Fail. Message={0}
+io.personium.core.msg.PL-SV-0004=memcached port should be in integer format. Message={0}
+io.personium.core.msg.PL-SV-0005=Failed to connect to memcached server at {0}:{1}. Message={2}
+io.personium.core.msg.PL-SV-0006=Failed to set cache. Message={0}
+io.personium.core.msg.PL-SV-0007=Failed to clear cache. Message={0}
+io.personium.core.msg.PL-SV-0008=Failed to delete cache. Message={0}
+io.personium.core.msg.PL-SV-0009=Authentic Data Store Entity Bulk Create Fail. Message={0}
+io.personium.core.msg.PL-SV-0010=Failed to connect to the RDB. Message={0}
+io.personium.core.msg.PL-SV-0011=Failed to execute Query SQL. Message={0}
+io.personium.core.msg.PL-SV-0012=Failed to close RDB connection. Message={0}
+io.personium.core.msg.PL-SV-0013=Ads connection error. Message={0}
+io.personium.core.msg.PL-SV-0014=ES index [{0}] does not exist.
+io.personium.core.msg.PL-SV-0015=Failed to create Ads for data bundle [{0}].
+io.personium.core.msg.PL-SV-0016=JDBC ExecSql : {0}
+io.personium.core.msg.PL-SV-0017=Failed to start server.
+io.personium.core.msg.PL-SV-0018=JDBC Req db={0} table={1} id={2} type={3} cellid={4} boxid={5} nodeid={6} entityid={7}
+io.personium.core.msg.PL-SV-0019=Set reference only lock. unit=[{0}]
+io.personium.core.msg.PL-SV-0020=Failed to write failure log for ads error.
+io.personium.core.msg.PL-SV-0021=Log info for ads error. [{0}]
+io.personium.core.msg.PL-SV-0022=RequestKey {0}: [{1}]
+
+# Auth
+io.personium.core.msg.PL-AU-0001=Token parse error. Reason={0}
+io.personium.core.msg.PL-AU-0002=Token disg error. Reason={0}
+io.personium.core.msg.PL-AU-0003=Root Ca crt setting error. Reason={0}
+io.personium.core.msg.PL-AU-0004=Account is already deleted [name={0}].
+io.personium.core.msg.PL-AU-0005=Requested type={0} not available in account Name={1}.
+
+#Authn
+io.personium.core.msg.PL-AN-0001=Authentication failed. No such account. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0002=Authentication failed. Consecutive authentication trial before valid authentication interval. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0003=Authentication failed. Account is locked. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0004=Authentication failed. Incorrect password. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0005=Authentication failed. Authentication trial from outside the IP address range. [{0}] [{1}] [{2}]
+io.personium.core.msg.PL-AN-0006=Authentication failed. Account is deactivated. [{0}] [{1}] [{2}]
+
+# OIDC
+io.personium.core.msg.PL-OI-0001=No such account. Name={0}
+io.personium.core.msg.PL-OI-0002=Requested type={0} not available in account Name={1}.
+io.personium.core.msg.PL-OI-0003=Invalid account Name={0}.
+io.personium.core.msg.PL-OI-0004=Issuer={0} not Google authorized.
+io.personium.core.msg.PL-OI-0005=Account is deactivated. [{0}] [{1}] [{2}]
+
+## ServiceCollection
+io.personium.core.msg.PL-SC-0001=[EngineRelay] Start. Method={0} Url={1}
+io.personium.core.msg.PL-SC-0002=[EngineRelay] End. (%timems)
+
+## Elastic Search
+io.personium.core.msg.PL-ES-0001=Connected to {0}
+io.personium.core.msg.PL-ES-0002=ESReq index={0} type={1} node={2} reqType={4} data={3}
+io.personium.core.msg.PL-ES-0003=Creating index [{0}].
+io.personium.core.msg.PL-ES-0004=ESReq index={0} type={1} node={2} reqType={3} data={4}
+io.personium.core.msg.PL-ES-0005=ESReqBody data={0}
+
+## Misc
+io.personium.core.msg.PL-MC-0001=Unreachable code error.
+
+### PS ScreenMessage
+## error API
+io.personium.core.msg.PS-ER-0001=ERROR
+io.personium.core.msg.PS-ER-0002=The code is undefined.
+#io.personium.core.msg.PS-ER-0003=Authorization failed.
+
+## auth form API
+io.personium.core.msg.PS-AU-0001=OAuth2 authorization endpoint
+io.personium.core.msg.PS-AU-0002=The following application is trying to access your data.<br />If there is no problem, please perform the authentication.
+io.personium.core.msg.PS-AU-0003=Please input user ID and password.
+io.personium.core.msg.PS-AU-0004=User ID or password is incorrect.
+io.personium.core.msg.PS-AU-0005=Authentication period has been passed, you must be authorized again.
+io.personium.core.msg.PS-AU-0006=The password should be changed.
+io.personium.core.msg.PS-AU-0007=Please input password.
+io.personium.core.msg.PS-AU-0008=Password format is invalid.
+io.personium.core.msg.PS-AU-0009=Failed to update password.
+

--- a/src/test/resources/personium-unit-config-oidcpluginloadertest.properties
+++ b/src/test/resources/personium-unit-config-oidcpluginloadertest.properties
@@ -1,0 +1,27 @@
+
+io.personium.plugin.oidc.OIDCConfig001.enabled=true
+io.personium.plugin.oidc.OIDCConfig001.configURL=https://localhost/.well-known/openid-configuration
+io.personium.plugin.oidc.OIDCConfig001.trustedClientIds=001_client001
+io.personium.plugin.oidc.OIDCConfig001.pluginName=OpenID Authentication Plugin
+io.personium.plugin.oidc.OIDCConfig001.accountType=accountType001
+io.personium.plugin.oidc.OIDCConfig001.accountNameKey=name
+io.personium.plugin.oidc.OIDCConfig001.grantType=grantType001
+
+io.personium.plugin.oidc.OIDCConfig002.enabled=true
+io.personium.plugin.oidc.OIDCConfig002.configURL=https://localhost/.well-known/openid-configuration
+io.personium.plugin.oidc.OIDCConfig002.trustedClientIds=002_client001
+io.personium.plugin.oidc.OIDCConfig002.pluginName=OpenID Authentication Plugin
+io.personium.plugin.oidc.OIDCConfig002.accountType=accountType002
+io.personium.plugin.oidc.OIDCConfig002.accountNameKey=name
+io.personium.plugin.oidc.OIDCConfig002.grantType=grantType002
+
+io.personium.plugin.oidc.OIDCConfig003.enabled=false
+
+io.personium.plugin.oidc.OIDCConfig004.enabled=true
+io.personium.plugin.oidc.OIDCConfig004.configURL=https://localhost/.well-known/openid-configuration
+io.personium.plugin.oidc.OIDCConfig004.trustedClientIds=004_client001
+io.personium.plugin.oidc.OIDCConfig004.pluginName=OpenID Authentication Plugin
+io.personium.plugin.oidc.OIDCConfig004.accountType=accountType004
+io.personium.plugin.oidc.OIDCConfig004.accountNameKey=name
+io.personium.plugin.oidc.OIDCConfig004.grantType=grantType004
+

--- a/src/test/resources/personium-unit-config.properties
+++ b/src/test/resources/personium-unit-config.properties
@@ -41,6 +41,7 @@ io.personium.core.pathBasedCellUrl.enabled=true
 
 # plugin
 io.personium.core.plugin.path=/personium/plugins
+io.personium.core.plugin.defaultClassname=io.personium.test.jersey.plugin.AuthPluginForAuthTest
 
 # engine configurations
 # io.personium.core.engine.host=localhost

--- a/src/test/resources/request/authn/plugin-auth.txt
+++ b/src/test/resources/request/authn/plugin-auth.txt
@@ -4,4 +4,4 @@ Content-Type: application/x-www-form-urlencoded
 Content-Length: ?
 Connection: close
 
-grant_type=urn:x-personium:oidc:${id_provider}&id_token=${id_token}
+grant_type=${grant_type}&${key_param}=${param}


### PR DESCRIPTION
This PR contains below features.

Related to
- https://github.com/personium/personium-plugin-base/pull/23
- https://github.com/personium/personium-plugins/pull/15

## PersoniumUnitConfig

- Added option `io.personium.core.plugin.defaultClassname` for plugin classname loaded by default.

## PluginLoader update

- Made plugin use `io.personium.core.plugin.defaultClassname` to determine plugin classname to load.
- Made `io.personium.plugin.base.auth.AuthPluginLoader` loadable.
- Replaced `System.out.println` with `log.info`.

## Modifing Test Codes

- Added UnitTest for `io.personium.core.plugin.PluginManager` and `io.personium.core.plugin.PluginsLoader`
- Replaced hard-coded string `oidc:google` with grantType of mocked class.
- Removed tests about verifing id_token (moved to `personium-plugins` project).