### PR TITLE
Add sign API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,11 @@
             <artifactId>guava</artifactId>
             <version>30.1.1-jre</version>
         </dependency>
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>0.7.9</version>
+        </dependency>
 
         <!-- For test. -->
         <dependency>
@@ -303,18 +308,10 @@
     <build>
         <finalName>${final.name}</finalName>
         <resources>
-                <resource>
-                    <directory>src/main/resources</directory>
-                    <filtering>true</filtering>
-                </resource>
-                <resource>
-                        <directory>..</directory>
-                        <includes>
-                                <include>LICENSE.txt</include>
-                                <include>NOTICE.txt</include>
-                                <include>CHANGES.txt</include>
-                        </includes>
-                </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
         </resources>
 
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.personium</groupId>
             <artifactId>personium-plugins</artifactId>
-            <version>1.0.9-SNAPSHOT</version>
+            <version>1.0.8</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
             <artifactId>guava</artifactId>
             <version>30.1.1-jre</version>
         </dependency>
+        <!-- Using jose4j instead of cxf-rt-rs-security-jose for signing byte array -->
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>io.personium</groupId>
             <artifactId>personium-lib-common</artifactId>
-            <version>1.5.4</version>
+            <version>1.5.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.personium</groupId>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.personium</groupId>
             <artifactId>personium-plugins</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.9-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/personium/core/PersoniumCoreException.java
+++ b/src/main/java/io/personium/core/PersoniumCoreException.java
@@ -1009,7 +1009,12 @@ public class PersoniumCoreException extends RuntimeException {
          * {1} : Configured authority
          */
         public static final PersoniumCoreException INVALID_URL_AUTHORITY = create("PR400-CM-0005");
-
+        /**
+         * Requested media type is not acceptable.
+         * <p>
+         * {0} : Given media type
+         */
+        public static final PersoniumCoreException MEDIATYPE_NOT_ACCEPTABLE = create("PR406-CM-0001");
         /**
          * Executing API that is not allowed when the cell status is "import failed".
          */

--- a/src/main/java/io/personium/core/auth/CellPrivilege.java
+++ b/src/main/java/io/personium/core/auth/CellPrivilege.java
@@ -73,6 +73,8 @@ public class CellPrivilege extends Privilege {
     public static final CellPrivilege RULE = new CellPrivilege("rule", ACCESS_TYPE_WRITE, ROOT);
     /** Rule read privilege. */
     public static final CellPrivilege RULE_READ = new CellPrivilege("rule-read", ACCESS_TYPE_READ, RULE);
+    /** Sign privilege. */
+    public static final CellPrivilege SIGN = new CellPrivilege("sign", ACCESS_TYPE_EXEC, ROOT);
 
     static Map<String, CellPrivilege> map = new HashMap<String, CellPrivilege>();
 
@@ -104,6 +106,7 @@ public class CellPrivilege extends Privilege {
         register(PROPFIND);
         register(RULE);
         register(RULE_READ);
+        register(SIGN);
     }
 
     private static void register(final CellPrivilege p) {

--- a/src/main/java/io/personium/core/model/CellKeyPair.java
+++ b/src/main/java/io/personium/core/model/CellKeyPair.java
@@ -1,0 +1,56 @@
+/**
+ * Personium
+ * Copyright 2019-2021 Personium Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.model;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+/**
+ * Class dealing with cell specific key information.
+ */
+public interface CellKeyPair {
+
+    /**
+     * Get Key ID.
+     * @return Key ID
+     */
+    public String getKeyId();
+
+    /**
+     * Get Public key.
+     * @return Public key
+     */
+    public byte[] getPublicKeyBytes();
+
+    /**
+     * Get Public key.
+     * @return Public key
+     */
+    public PublicKey getPublicKey();
+
+    /**
+     * Get Private key.
+     * @return Private key
+     */
+    public byte[] getPrivateKeyBytes();
+
+    /**
+     * Get Private key.
+     * @return Private key
+     */
+    public PrivateKey getPrivateKey();
+}

--- a/src/main/java/io/personium/core/model/CellKeys.java
+++ b/src/main/java/io/personium/core/model/CellKeys.java
@@ -1,7 +1,6 @@
 /**
  * Personium
- * Copyright 2014-2021 Personium Project Authors
- * - FUJITSU LIMITED
+ * Copyright 2019-2021 Personium Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +17,22 @@
 package io.personium.core.model;
 
 /**
- * Interface of parts corresponding to Cell.
+ * Interface that manages cell specific key information.
  */
-public interface CellCmp extends DavCmp {
+public interface CellKeys {
 
     /**
-     * Set cell status and save metadata file.
-     * @param status cell status
-     */
-    void setCellStatusAndSave(String status);
-
-    /**
-     * Get CellKeys.
+     * Read the keys file.
+     * If it does not exist, it creates and returns it.
      * @return CellKeys
      */
-    CellKeys getCellKeys();
+    public CellKeys load();
+
+    /**
+     * Get CellKeysFile.
+     * Currently return only one.
+     * In the future we will return map with another method.
+     * @return CellKeysFile
+     */
+    public CellKeyPair getCellKeyPairs();
 }

--- a/src/main/java/io/personium/core/model/impl/fs/CellCmpFsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/fs/CellCmpFsImpl.java
@@ -32,6 +32,7 @@ import io.personium.core.PersoniumCoreException;
 import io.personium.core.PersoniumUnitConfig;
 import io.personium.core.model.Cell;
 import io.personium.core.model.CellCmp;
+import io.personium.core.model.CellKeys;
 import io.personium.core.model.DavCmp;
 import io.personium.core.model.lock.Lock;
 import io.personium.core.model.lock.LockManager;
@@ -76,7 +77,7 @@ public class CellCmpFsImpl extends DavCmpFsImpl implements CellCmp {
         this.load();
         // When accessing under Cell, read it every time.
         // In case of performance problems, fix it to read with "__token, __authz, __certs".
-        cellKeys = new CellKeys(Paths.get(fsPath, CellKeys.KEYS_DIR_NAME));
+        cellKeys = new CellKeysFsImpl(Paths.get(fsPath, CellKeysFsImpl.KEYS_DIR_NAME));
         cellKeys.load();
     }
 

--- a/src/main/java/io/personium/core/model/impl/fs/CellKeyPairFsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/fs/CellKeyPairFsImpl.java
@@ -41,13 +41,14 @@ import org.slf4j.LoggerFactory;
 
 import io.personium.core.PersoniumCoreException;
 import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.model.CellKeyPair;
 
 /**
  * Class dealing with cell specific key information.
  */
-public class CellKeysFile {
+public class CellKeyPairFsImpl implements CellKeyPair {
     /** Logger. */
-    private static Logger log = LoggerFactory.getLogger(CellKeysFile.class);
+    private static Logger log = LoggerFactory.getLogger(CellKeyPairFsImpl.class);
 
     /** Algorithm at key creation. */
     private static final String KEY_ALGORITHM = "RSA";
@@ -76,7 +77,7 @@ public class CellKeysFile {
      * Constructor.
      * @param keysDirPath Keys file storage directory path
      */
-    private CellKeysFile(Path keysDirPath) {
+    private CellKeyPairFsImpl(Path keysDirPath) {
         this.keysDirPath = keysDirPath;
     }
 
@@ -85,7 +86,7 @@ public class CellKeysFile {
      * @param keysDirPath Keys file storage directory path
      * @param keyId Key ID
      */
-    private CellKeysFile(Path keysDirPath, String keyId) {
+    private CellKeyPairFsImpl(Path keysDirPath, String keyId) {
         this.keysDirPath = keysDirPath;
         this.keyId = keyId;
     }
@@ -98,8 +99,8 @@ public class CellKeysFile {
      *        Directories of keyId is created under this.
      * @return Created new instance.
      */
-    public static CellKeysFile newInstance(Path keysDirPath) { // CHECKSTYLE IGNORE
-        CellKeysFile cellKeysFile = new CellKeysFile(keysDirPath);
+    public static CellKeyPairFsImpl newInstance(Path keysDirPath) { // CHECKSTYLE IGNORE
+        CellKeyPairFsImpl cellKeysFile = new CellKeyPairFsImpl(keysDirPath);
         try {
             cellKeysFile.createKeys();
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
@@ -115,8 +116,8 @@ public class CellKeysFile {
      * @param keyId Key ID
      * @return Loaded instance
      */
-    public static CellKeysFile load(Path keysDirPath, String keyId) { // CHECKSTYLE IGNORE
-        CellKeysFile cellKeysFile = new CellKeysFile(keysDirPath, keyId);
+    public static CellKeyPairFsImpl load(Path keysDirPath, String keyId) { // CHECKSTYLE IGNORE
+        CellKeyPairFsImpl cellKeysFile = new CellKeyPairFsImpl(keysDirPath, keyId);
 
         int retryCount = 0;
         while (true) {

--- a/src/main/java/io/personium/core/model/impl/fs/CellKeysFsImpl.java
+++ b/src/main/java/io/personium/core/model/impl/fs/CellKeysFsImpl.java
@@ -27,13 +27,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.personium.core.PersoniumCoreException;
+import io.personium.core.model.CellKeyPair;
+import io.personium.core.model.CellKeys;
 
 /**
  * Class that manages cell specific key information.
  */
-public class CellKeys {
+public class CellKeysFsImpl implements CellKeys {
     /** Logger. */
-    private static Logger log = LoggerFactory.getLogger(CellKeys.class);
+    private static Logger log = LoggerFactory.getLogger(CellKeysFsImpl.class);
 
     /** Keys file storage directory name. */
     public static final String KEYS_DIR_NAME = ".pkeys";
@@ -43,7 +45,7 @@ public class CellKeys {
      * It is a map because there is a possibility of having two or more information in the future.
      * Currently only one can be created.
      */
-    private Map<String, CellKeysFile> keysFileMap;
+    private Map<String, CellKeyPairFsImpl> keysFileMap;
     /** Keys file storage directory path. */
     private Path keysDirPath;
 
@@ -51,7 +53,7 @@ public class CellKeys {
      * Constructor.
      * @param keysDirPath Keys file storage directory path
      */
-    public CellKeys(Path keysDirPath) {
+    public CellKeysFsImpl(Path keysDirPath) {
         keysFileMap = new HashMap<>();
         this.keysDirPath = keysDirPath;
     }
@@ -79,8 +81,8 @@ public class CellKeys {
      * In the future we will return map with another method.
      * @return CellKeysFile
      */
-    public CellKeysFile getCellKeysFile() {
-        CellKeysFile cellKeysFile = null;
+    public CellKeyPair getCellKeyPairs() {
+        CellKeyPair cellKeysFile = null;
         for (String keyId : keysFileMap.keySet()) {
             cellKeysFile = keysFileMap.get(keyId);
         }
@@ -109,7 +111,7 @@ public class CellKeys {
      */
     private void doLoad() {
         for (String keyId : keysDirPath.toFile().list()) {
-            CellKeysFile cellKeysFile = CellKeysFile.load(keysDirPath, keyId);
+            CellKeyPairFsImpl cellKeysFile = CellKeyPairFsImpl.load(keysDirPath, keyId);
             keysFileMap.put(keyId, cellKeysFile);
         }
     }
@@ -118,7 +120,7 @@ public class CellKeys {
      * Create keys file.
      */
     private void doCreate() {
-        CellKeysFile cellKeysFile = CellKeysFile.newInstance(keysDirPath);
+        CellKeyPairFsImpl cellKeysFile = CellKeyPairFsImpl.newInstance(keysDirPath);
         // Perform presence check again just before file writing.
         // To reduce the risk of writing at the same timing.
         if (exists()) {

--- a/src/main/java/io/personium/core/rs/PersoniumCoreExceptionMapper.java
+++ b/src/main/java/io/personium/core/rs/PersoniumCoreExceptionMapper.java
@@ -20,6 +20,8 @@ package io.personium.core.rs;
 import java.util.UUID;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -38,6 +40,9 @@ import io.personium.core.exceptions.ODataErrorMessage;
 public final class PersoniumCoreExceptionMapper implements ExceptionMapper<Exception> {
     static final int ERROR_ID_ROOT = 100000;
     static Logger log = LoggerFactory.getLogger(PersoniumCoreExceptionMapper.class);
+
+    @Context
+    HttpHeaders headers;
 
     @Override
     public Response toResponse(final Exception exception) {
@@ -89,6 +94,9 @@ public final class PersoniumCoreExceptionMapper implements ExceptionMapper<Excep
             return this.handlePersoniumCoreException(PersoniumCoreException.Misc.NOT_FOUND);
         } else if (HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE == res.getStatus()) {
             return this.handlePersoniumCoreException(PersoniumCoreException.Misc.UNSUPPORTED_MEDIA_TYPE_NO_PARAMS);
+        } else if (HttpStatus.SC_NOT_ACCEPTABLE == res.getStatus()) {
+            return this.handlePersoniumCoreException(PersoniumCoreException.Common.MEDIATYPE_NOT_ACCEPTABLE
+                .params(headers.getHeaderString(HttpHeaders.ACCEPT)));
         }
         return res;
     }

--- a/src/main/java/io/personium/core/rs/cell/AuthzEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/AuthzEndPointResource.java
@@ -82,6 +82,7 @@ import io.personium.core.auth.ScopeArbitrator;
 import io.personium.core.model.Box;
 import io.personium.core.model.Cell;
 import io.personium.core.model.CellCmp;
+import io.personium.core.model.CellKeyPair;
 import io.personium.core.model.CellRsCmp;
 import io.personium.core.model.ModelFactory;
 import io.personium.core.model.ctl.Account;
@@ -89,7 +90,6 @@ import io.personium.core.model.impl.es.EsModel;
 import io.personium.core.model.impl.es.QueryMapFactory;
 import io.personium.core.model.impl.es.accessor.EntitySetAccessor;
 import io.personium.core.model.impl.es.doc.OEntityDocHandler;
-import io.personium.core.model.impl.fs.CellKeysFile;
 import io.personium.core.odata.OEntityWrapper;
 import io.personium.core.odata.PersoniumODataProducer;
 import io.personium.core.rs.FacadeResource;
@@ -585,12 +585,12 @@ public class AuthzEndPointResource {
             }
         } else {
             CellCmp cellCmp = (CellCmp) cellRsCmp.getDavCmp();
-            CellKeysFile cellKeysFile = cellCmp.getCellKeys().getCellKeysFile();
+            CellKeyPair cellKeyPair = cellCmp.getCellKeys().getCellKeyPairs();
             long issuedAtSec = issuedAt / AbstractOAuth2Token.MILLISECS_IN_A_SEC;
             long expiryTime = issuedAtSec + AbstractOAuth2Token.SECS_IN_AN_HOUR;
             IdToken idToken = new IdToken(
-                    cellKeysFile.getKeyId(), AlgorithmUtils.RS_SHA_256_ALGO, getIssuerUrl(),
-                    username, schema, expiryTime, issuedAtSec, cellKeysFile.getPrivateKey());
+                    cellKeyPair.getKeyId(), AlgorithmUtils.RS_SHA_256_ALGO, getIssuerUrl(),
+                    username, schema, expiryTime, issuedAtSec, cellKeyPair.getPrivateKey());
             paramMap.put(OAuth2Helper.Key.ID_TOKEN, idToken.toTokenString());
         }
 
@@ -700,13 +700,13 @@ public class AuthzEndPointResource {
             }
         } else {
             CellCmp cellCmp = (CellCmp) cellRsCmp.getDavCmp();
-            CellKeysFile cellKeysFile = cellCmp.getCellKeys().getCellKeysFile();
+            CellKeyPair cellKeyPair = cellCmp.getCellKeys().getCellKeyPairs();
             String subject = token.getSubject();
             long issuedAtSec = issuedAt / AbstractOAuth2Token.MILLISECS_IN_A_SEC;
             long expiryTime = issuedAtSec + AbstractOAuth2Token.SECS_IN_AN_HOUR;
             IdToken idToken = new IdToken(
-                    cellKeysFile.getKeyId(), AlgorithmUtils.RS_SHA_256_ALGO, getIssuerUrl(),
-                    subject, clientId, expiryTime, issuedAtSec, cellKeysFile.getPrivateKey());
+                    cellKeyPair.getKeyId(), AlgorithmUtils.RS_SHA_256_ALGO, getIssuerUrl(),
+                    subject, clientId, expiryTime, issuedAtSec, cellKeyPair.getPrivateKey());
             paramMap.put(OAuth2Helper.Key.ID_TOKEN, idToken.toTokenString());
         }
         if (StringUtils.isNotEmpty(state)) {

--- a/src/main/java/io/personium/core/rs/cell/CellResource.java
+++ b/src/main/java/io/personium/core/rs/cell/CellResource.java
@@ -430,6 +430,15 @@ public class CellResource {
     }
 
     /**
+     * Sign endpoint.
+     * @return SignResource
+     */
+    @Path("__sign")
+    public SignResource sign() {
+        return new SignResource(cellRsCmp, cellCmp);
+    }
+
+    /**
      * Certs endpoint.(OpenID Connect).
      * @return CertsResource
      */

--- a/src/main/java/io/personium/core/rs/cell/CertsResource.java
+++ b/src/main/java/io/personium/core/rs/cell/CertsResource.java
@@ -30,7 +30,7 @@ import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
 import org.apache.cxf.rs.security.jose.jwk.JwkUtils;
 
 import io.personium.core.model.CellCmp;
-import io.personium.core.model.impl.fs.CellKeysFile;
+import io.personium.core.model.CellKeyPair;
 import io.personium.core.utils.ResourceUtils;
 
 /**
@@ -57,10 +57,10 @@ public class CertsResource {
      */
     @GET
     public Response get() {
-        CellKeysFile cellKeysFile = cellCmp.getCellKeys().getCellKeysFile();
-        RSAPublicKey publicKey = (RSAPublicKey) cellKeysFile.getPublicKey();
+        CellKeyPair cellKeyPair = cellCmp.getCellKeys().getCellKeyPairs();
+        RSAPublicKey publicKey = (RSAPublicKey) cellKeyPair.getPublicKey();
         JsonWebKey jwk = JwkUtils.fromRSAPublicKey(
-                publicKey, AlgorithmUtils.RS_SHA_256_ALGO, cellKeysFile.getKeyId());
+                publicKey, AlgorithmUtils.RS_SHA_256_ALGO, cellKeyPair.getKeyId());
         JsonWebKeys jwks = new JsonWebKeys(jwk);
         return Response.ok(JwkUtils.jwkSetToJson(jwks), MediaType.APPLICATION_JSON).build();
     }

--- a/src/main/java/io/personium/core/rs/cell/SignResource.java
+++ b/src/main/java/io/personium/core/rs/cell/SignResource.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.PrivateKey;
 
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
@@ -33,7 +32,6 @@ import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 
-import io.personium.core.PersoniumCoreException;
 import io.personium.core.auth.CellPrivilege;
 import io.personium.core.model.CellCmp;
 import io.personium.core.model.CellRsCmp;
@@ -64,15 +62,6 @@ public class SignResource {
     }
 
     /**
-     * Default handler
-     * @return no response
-     */
-    @POST
-    public Response post(@HeaderParam("accept") String accept) {
-        throw PersoniumCoreException.Common.MEDIATYPE_NOT_ACCEPTABLE.params(accept);
-    }
-
-    /**
      * Generating JWS from received InputStream
      * @param inputStream
      * @return
@@ -100,7 +89,7 @@ public class SignResource {
         }
 
         try {
-            // TODO: To avoid outofmemory, modify function not to copy entire stream on byte array.
+            //TODO To avoid outofmemory, modify function not to copy entire stream on byte array.
             return signJWS(IOUtils.toByteArray(inputStream));
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/io/personium/core/rs/cell/SignResource.java
+++ b/src/main/java/io/personium/core/rs/cell/SignResource.java
@@ -115,7 +115,7 @@ public class SignResource {
         jws.setKeyIdHeaderValue(cellKeyPair.getKeyId());
 
         // Currently support only RS256
-        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_PSS_USING_SHA256);
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
 
         String result = null;
         try {

--- a/src/main/java/io/personium/core/rs/cell/SignResource.java
+++ b/src/main/java/io/personium/core/rs/cell/SignResource.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.PrivateKey;
 
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
@@ -32,6 +33,7 @@ import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 
+import io.personium.core.PersoniumCoreException;
 import io.personium.core.auth.CellPrivilege;
 import io.personium.core.model.CellCmp;
 import io.personium.core.model.CellRsCmp;
@@ -62,9 +64,16 @@ public class SignResource {
     }
 
     /**
+     * Default handler
+     * @return no response
+     */
+    @POST
+    public Response post(@HeaderParam("accept") String accept) {
+        throw PersoniumCoreException.Common.MEDIATYPE_NOT_ACCEPTABLE.params(accept);
+    }
+
+    /**
      * Generating JWS from received InputStream
-     * @param contentType
-     * @param accept
      * @param inputStream
      * @return
      */
@@ -91,7 +100,7 @@ public class SignResource {
         }
 
         try {
-            // TODO: check the content size
+            // TODO: To avoid outofmemory, modify function not to copy entire stream on byte array.
             return signJWS(IOUtils.toByteArray(inputStream));
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/io/personium/core/rs/cell/SignResource.java
+++ b/src/main/java/io/personium/core/rs/cell/SignResource.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
@@ -124,7 +125,12 @@ public class SignResource {
 
         jws.setKey(privKey);
         jws.setKeyIdHeaderValue(cellKeyPair.getKeyId());
-        jws.setAlgorithmHeaderValue(privKey.getAlgorithm());
+
+        String alg = null;
+        if ("RSA".equals(privKey.getAlgorithm())) {
+            alg = AlgorithmIdentifiers.RSA_PSS_USING_SHA256;
+        };
+        jws.setAlgorithmHeaderValue(alg);
 
         String result = null;
         try {

--- a/src/main/java/io/personium/core/rs/cell/SignResource.java
+++ b/src/main/java/io/personium/core/rs/cell/SignResource.java
@@ -1,0 +1,146 @@
+/**
+ * Personium
+ * Copyright 2018-2021 Personium Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.rs.cell;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PrivateKey;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.lang.JoseException;
+import org.slf4j.Logger;
+
+import io.personium.core.auth.CellPrivilege;
+import io.personium.core.model.CellCmp;
+import io.personium.core.model.CellRsCmp;
+import io.personium.core.model.CellKeyPair;
+import io.personium.core.utils.ResourceUtils;
+
+/**
+ * JAX-RS resource. Endpoint that handles signing contents
+ */
+public class SignResource {
+    static final String MEDIATYPE_JOSE = "application/jose";
+
+    static Logger log = org.slf4j.LoggerFactory.getLogger(CellResource.class);
+
+    /** cell resource information. */
+    private CellRsCmp cellRsCmp;
+
+    /** Target cell information. */
+    private CellCmp cellCmp;
+
+    /**
+     * Constructor.
+     * @param cellRsCmp CellCmp
+     */
+    public SignResource(CellRsCmp cellRsCmp, CellCmp cellCmp) {
+        this.cellRsCmp = cellRsCmp;
+        this.cellCmp = cellCmp;
+    }
+
+    /**
+     * Generating JWS from received InputStream
+     * @param contentType
+     * @param accept
+     * @param inputStream
+     * @return
+     */
+    @POST
+    public Response post(@HeaderParam(HttpHeaders.CONTENT_TYPE) final String contentType,
+            @HeaderParam(HttpHeaders.ACCEPT) final String accept,
+            final InputStream inputStream) {
+        // Access Control
+        this.cellRsCmp.checkAccessContext(CellPrivilege.SIGN);
+
+        // set default accept header to "application/jose"
+        String acceptHeader = StringUtils.isNotEmpty(accept) ? accept : MEDIATYPE_JOSE;
+
+        String result = null;
+        if (MEDIATYPE_JOSE.equals(acceptHeader)) {
+            try {
+                result = signJWS(inputStream);
+            } catch(IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            Response.status(Status.NOT_ACCEPTABLE);
+        }
+
+        return Response.ok(result, "application/jose").build();
+    }
+
+    /**
+     * Generate JWS from stream
+     * @param inputStream   payload data stream
+     * @return              Signed JWS
+     * @throws IOException  Exception
+     */
+    public String signJWS(InputStream inputStream) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            IOUtils.copy(inputStream, baos);
+            return signJWS(baos.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Generate JWS from bytes
+     * @param plainJwsPayload   payload data bytes
+     * @return  Signed JWS
+     */
+    public String signJWS(byte[] plainJwsPayload) {
+        CellKeyPair cellKeyPair = cellCmp.getCellKeys().getCellKeyPairs();
+        PrivateKey privKey = cellKeyPair.getPrivateKey();
+
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayloadBytes(plainJwsPayload);
+
+        jws.setKey(privKey);
+        jws.setKeyIdHeaderValue(cellKeyPair.getKeyId());
+        jws.setAlgorithmHeaderValue(privKey.getAlgorithm());
+
+        String result = null;
+        try {
+            result = jws.getCompactSerialization();
+        } catch (JoseException e) {
+            throw new RuntimeException("Happens an exception in generating JWS", e);
+        }
+        return result;
+    }
+
+    /**
+     * Processing of the OPTIONS method.
+     * @return JAX-RS response object
+     */
+    @OPTIONS
+    public Response options() {
+        return ResourceUtils.responseBuilderForOptions(HttpMethod.POST).build();
+    }
+}

--- a/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
+++ b/src/main/java/io/personium/core/rs/cell/TokenEndPointResource.java
@@ -79,9 +79,9 @@ import io.personium.core.auth.ScopeArbitrator;
 import io.personium.core.model.Box;
 import io.personium.core.model.Cell;
 import io.personium.core.model.CellCmp;
+import io.personium.core.model.CellKeyPair;
 import io.personium.core.model.CellRsCmp;
 import io.personium.core.model.ctl.Account;
-import io.personium.core.model.impl.fs.CellKeysFile;
 import io.personium.core.odata.OEntityWrapper;
 import io.personium.core.plugin.PluginInfo;
 import io.personium.core.plugin.PluginManager;
@@ -551,13 +551,13 @@ public class TokenEndPointResource {
         Set<String> reqScopes = new HashSet<>(Arrays.asList(grantCode.getScope()));
         if (reqScopes.contains(OAuth2Helper.Scope.OPENID)) {
             CellCmp cellCmp = (CellCmp) davRsCmp.getDavCmp();
-            CellKeysFile cellKeysFile = cellCmp.getCellKeys().getCellKeysFile();
+            CellKeyPair cellKeyPair = cellCmp.getCellKeys().getCellKeyPairs();
             String subject = grantCode.getSubject();
             long issuedAtSec = issuedAt / AbstractOAuth2Token.MILLISECS_IN_A_SEC;
             long expiryTime = issuedAtSec + AbstractOAuth2Token.SECS_IN_AN_HOUR;
             idToken = new IdToken(
-                    cellKeysFile.getKeyId(), AlgorithmUtils.RS_SHA_256_ALGO, getIssuerUrl(),
-                    subject, schema, expiryTime, issuedAtSec, cellKeysFile.getPrivateKey());
+                    cellKeyPair.getKeyId(), AlgorithmUtils.RS_SHA_256_ALGO, getIssuerUrl(),
+                    subject, schema, expiryTime, issuedAtSec, cellKeyPair.getPrivateKey());
         }
 
         return this.responseAuthSuccess(aToken, rToken, idToken, issuedAt);

--- a/src/main/java/io/personium/core/snapshot/SnapshotFileExportVisitor.java
+++ b/src/main/java/io/personium/core/snapshot/SnapshotFileExportVisitor.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import io.personium.common.file.DataCryptor;
 import io.personium.core.auth.AuthHistoryLastFile;
-import io.personium.core.model.impl.fs.CellKeys;
+import io.personium.core.model.impl.fs.CellKeysFsImpl;
 import io.personium.core.model.impl.fs.DavCmpFsImpl;
 import io.personium.core.model.impl.fs.DavMetadataFile;
 
@@ -77,7 +77,7 @@ public class SnapshotFileExportVisitor implements FileVisitor<Path> {
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
         Path relativezeDir = webdavRootDir.relativize(dir);
         // Skip export pkeys and pauthhistory.
-        if (relativezeDir.startsWith(CellKeys.KEYS_DIR_NAME)
+        if (relativezeDir.startsWith(CellKeysFsImpl.KEYS_DIR_NAME)
                 || relativezeDir.startsWith(AuthHistoryLastFile.AUTH_HISTORY_DIRECTORY)) {
             return FileVisitResult.SKIP_SUBTREE;
         }

--- a/src/main/resources/personium-messages.properties
+++ b/src/main/resources/personium-messages.properties
@@ -371,6 +371,7 @@ io.personium.core.msg.PR400-CM-0002=Field [{0}] format error. Must be [{1}].
 io.personium.core.msg.PR400-CM-0003=Unknown key [{0}] specified.
 io.personium.core.msg.PR400-CM-0004=JSON parse error. [{0}].
 io.personium.core.msg.PR400-CM-0005=Invalid URL authority [{0}]. This unit is configured for URL authority [{1}]
+io.personium.core.msg.PR406-CM-0001=Requested media type [{0}] is not acceptable.
 
 io.personium.core.msg.PR409-CM-0001=Cell status is [import failed]. Only Unit Level's APIs, CellImport and GetToken are executable.
 io.personium.core.msg.PR409-CM-0002=Because [{0}] is being executed, writing to cell can not be done.

--- a/src/test/java/io/personium/core/rs/cell/SignResourceTest.java
+++ b/src/test/java/io/personium/core/rs/cell/SignResourceTest.java
@@ -184,14 +184,9 @@ public class SignResourceTest {
     /**
      * Testing that signJWS throws IllegalArgumentException when null is input
      */
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void signJWS_with_null_inputstream_throws_illegalargumentexception() {
-        try {
-            signResource.signJWS((InputStream) null);
-            fail("Exception is not thrown");
-        } catch (Exception e) {
-            assert (e instanceof IllegalArgumentException);
-        }
+        signResource.signJWS((InputStream) null);
     }
 
     /**
@@ -200,7 +195,7 @@ public class SignResourceTest {
      */
     @Test
     @Ignore
-    public void signJWS_with_too_large_inputstream_throws_ioexception() throws Exception {
+    public void signJWS_with_too_large_inputstream_throws_outofmemory() throws Exception {
         signAndVerify(1024, 1024 * 1024 * 1024); // 1TiB
     }
 }

--- a/src/test/java/io/personium/core/rs/cell/SignResourceTest.java
+++ b/src/test/java/io/personium/core/rs/cell/SignResourceTest.java
@@ -1,0 +1,140 @@
+/**
+ * Personium
+ * Copyright 2018-2021 Personium Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.core.rs.cell;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.security.PublicKey;
+import java.util.Random;
+
+import org.fusesource.hawtbuf.BufferInputStream;
+import org.jose4j.jws.JsonWebSignature;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.personium.core.PersoniumUnitConfig;
+import io.personium.core.auth.AccessContext;
+import io.personium.core.model.Cell;
+import io.personium.core.model.CellCmp;
+import io.personium.core.model.CellKeyPair;
+import io.personium.core.model.CellKeys;
+import io.personium.core.model.CellRsCmp;
+import io.personium.core.model.ModelFactory;
+import io.personium.core.model.impl.fs.CellKeyPairFsImpl;
+import io.personium.core.model.lock.UnitUserLockManager;
+import io.personium.test.categories.Unit;
+
+/**
+ * Unit Test class for SignResource.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ AccessContext.class, ModelFactory.class, PersoniumUnitConfig.class, UnitUserLockManager.class })
+@Category({ Unit.class })
+public class SignResourceTest {
+
+    /** Test class. */
+    private SignResource signResource;
+
+    /**
+     * Mock CellResource.
+     * @param cell cell
+     * @param cellCmp cellCmp
+     * @param cellRsCmp cellRsCmp
+     * @param accessContext accessContext
+     * @throws Exception Unintended exception in test
+     */
+    private void initCellResource(
+            Cell cell, CellCmp cellCmp, CellRsCmp cellRsCmp, AccessContext accessContext) throws Exception {
+        // Mock settings
+        doReturn(cell).when(accessContext).getCell();
+        PowerMockito.mockStatic(ModelFactory.class);
+        PowerMockito.doReturn(cellCmp).when(ModelFactory.class, "cellCmp", any());
+        doReturn(true).when(cellCmp).exists();
+        PowerMockito.whenNew(CellRsCmp.class).withAnyArguments().thenReturn(cellRsCmp);
+        PowerMockito.mockStatic(PersoniumUnitConfig.class);
+        PowerMockito.doReturn("u0").when(PersoniumUnitConfig.class, "getEsUnitPrefix");
+        PowerMockito.doReturn(null).when(PersoniumUnitConfig.class, "getLockType");
+        PowerMockito.doReturn("0").when(PersoniumUnitConfig.class, "getLockRetryInterval");
+        PowerMockito.doReturn("0").when(PersoniumUnitConfig.class, "getLockRetryTimes");
+        PowerMockito.doReturn(null).when(PersoniumUnitConfig.class, "getLockMemcachedHost");
+        PowerMockito.doReturn(null).when(PersoniumUnitConfig.class, "getLockMemcachedPort");
+        PowerMockito.doReturn(0).when(PersoniumUnitConfig.class, "getAccountValidAuthnInterval");
+        PowerMockito.doReturn(0).when(PersoniumUnitConfig.class, "getAccountLockCount");
+        PowerMockito.doReturn(0).when(PersoniumUnitConfig.class, "getAccountLockTime");
+        PowerMockito.mockStatic(UnitUserLockManager.class);
+        PowerMockito.doReturn(false).when(UnitUserLockManager.class, "hasLockObject", anyString());
+        doReturn(Cell.STATUS_NORMAL).when(cellCmp).getCellStatus();
+        signResource = spy(new SignResource(cellRsCmp, cellCmp));
+    }
+
+    /**
+     * Testing that sign
+     * @throws Exception
+     */
+    @Test
+    public void Test_that_signResource_generates_valid_jws_from_InputStream() throws Exception {
+        // Mock settings
+        AccessContext accessContext = PowerMockito.mock(AccessContext.class);
+        Cell cell = mock(Cell.class);
+        CellCmp cellCmp = mock(CellCmp.class);
+        CellRsCmp cellRsCmp = mock(CellRsCmp.class);
+        initCellResource(cell, cellCmp, cellRsCmp, accessContext);
+
+        doNothing().when(accessContext).updateBasicAuthenticationStateForResource(null);
+        doReturn(AccessContext.TYPE_UNIT_MASTER).when(accessContext).getType();
+
+        cellCmp.getCellKeys();
+        CellKeys cellKeys = mock(CellKeys.class);
+        CellKeyPair tmpKeyPair = CellKeyPairFsImpl.newInstance(Paths.get("tmp"));
+
+        doReturn(tmpKeyPair).when(cellKeys).getCellKeyPairs();
+        doReturn(cellKeys).when(cellCmp).getCellKeys();
+
+        byte[] dummyToSign = new byte[1024 * 32];
+        new Random().nextBytes(dummyToSign);
+
+        try (InputStream inputStream = new BufferInputStream(dummyToSign)) {
+            String vcString = signResource.signJWS(inputStream);
+
+            JsonWebSignature jws = new JsonWebSignature();
+            jws.setCompactSerialization(vcString);
+
+            PublicKey publicKey = tmpKeyPair.getPublicKey();
+            jws.setKey(publicKey);
+
+            boolean signatureVerified = jws.verifySignature();
+
+            assertEquals("KeyID is not matched", tmpKeyPair.getKeyId(), jws.getKeyIdHeaderValue());
+            assertArrayEquals("Payload is not matched", dummyToSign, jws.getPayloadBytes());
+            assertTrue("Verifing JWS is failed", signatureVerified);
+        }
+    }
+}

--- a/src/test/java/io/personium/test/jersey/cell/AclTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/AclTest.java
@@ -2028,11 +2028,11 @@ public class AclTest extends AbstractCase {
     private void signTest(List<String> account) {
         // sign POST sign
         // UNIT_MASTER_TOKEN
-        SignUtils.post(TOKEN, "example", HttpStatus.SC_OK, TEST_CELL1).contentType("application/jose");
+        SignUtils.post(TEST_CELL1, TOKEN, "example", HttpStatus.SC_OK);
         // sign privilege
-        SignUtils.post(account.get(21), "example", HttpStatus.SC_OK, TEST_CELL1).contentType("application/jose");
+        SignUtils.post(TEST_CELL1, account.get(21), "example", HttpStatus.SC_OK);
         // other
-        SignUtils.post(account.get(0), "example", HttpStatus.SC_FORBIDDEN, TEST_CELL1).contentType("application/json");
+        SignUtils.post(TEST_CELL1, account.get(0), "example", HttpStatus.SC_FORBIDDEN);
     }
 
     /**

--- a/src/test/java/io/personium/test/jersey/cell/AclTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/AclTest.java
@@ -73,6 +73,7 @@ import io.personium.test.utils.RelationUtils;
 import io.personium.test.utils.ResourceUtils;
 import io.personium.test.utils.RoleUtils;
 import io.personium.test.utils.SentMessageUtils;
+import io.personium.test.utils.SignUtils;
 import io.personium.test.utils.TResponse;
 import io.personium.test.utils.TestMethodUtils;
 import io.personium.test.utils.UrlUtils;
@@ -993,6 +994,9 @@ public class AclTest extends AbstractCase {
                 "");
         DavResourceUtils.setACL(TEST_CELL1, account.get(16), HttpStatus.SC_FORBIDDEN, "", aclTestFile, Setup.TEST_BOX1,
                 "");
+
+        // sign
+        signTest(account);
     }
 
     /**
@@ -1269,6 +1273,8 @@ public class AclTest extends AbstractCase {
         result.add(ResourceUtils.getMyCellLocalToken(TEST_CELL1, "account29", "password29"));
         // 20 account30 log-read
         result.add(ResourceUtils.getMyCellLocalToken(TEST_CELL1, "account30", "password30"));
+        // 21 account31 sign
+        result.add(ResourceUtils.getMyCellLocalToken(TEST_CELL1, "account31", "password31"));
 
         // CellレベルACL設定
         String aclTestFile = "cell/acl-authtest.txt";
@@ -2017,6 +2023,16 @@ public class AclTest extends AbstractCase {
         ResourceUtils.logCollectionPropfind(TEST_CELL1, "archive", "0", account.get(13), HttpStatus.SC_FORBIDDEN);
         ResourceUtils.logCollectionPropfind(TEST_CELL1, "archive", "0", account.get(19), HttpStatus.SC_MULTI_STATUS);
         ResourceUtils.logCollectionPropfind(TEST_CELL1, "archive", "0", account.get(20), HttpStatus.SC_MULTI_STATUS);
+    }
+
+    private void signTest(List<String> account) {
+        // sign POST sign
+        // UNIT_MASTER_TOKEN
+        SignUtils.post(TOKEN, "example", HttpStatus.SC_OK, TEST_CELL1).contentType("application/jose");
+        // sign privilege
+        SignUtils.post(account.get(21), "example", HttpStatus.SC_OK, TEST_CELL1).contentType("application/jose");
+        // other
+        SignUtils.post(account.get(0), "example", HttpStatus.SC_FORBIDDEN, TEST_CELL1).contentType("application/json");
     }
 
     /**

--- a/src/test/java/io/personium/test/jersey/cell/AllTests.java
+++ b/src/test/java/io/personium/test/jersey/cell/AllTests.java
@@ -47,6 +47,7 @@ import io.personium.test.jersey.unit.UnitUserCellTest;
         PropPatchTest.class,
         ReadListTest.class,
         ReadTest.class,
+        SignTest.class,
         UnitUserCellTest.class,
         UpdateTest.class
 })

--- a/src/test/java/io/personium/test/jersey/cell/SignTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/SignTest.java
@@ -76,7 +76,8 @@ public class SignTest extends AbstractCase {
     @Test
     public void Test_that_cell_reject_accept_is_not_jose() {
         byte[] testBody = "example_text".getBytes(StandardCharsets.UTF_8);
-        SignUtils.post(Setup.TEST_CELL1, MASTER_TOKEN_NAME, "application/json", testBody, HttpStatus.SC_NOT_ACCEPTABLE);
+        TResponse res = SignUtils.post(Setup.TEST_CELL1, MASTER_TOKEN_NAME, "application/json", testBody, HttpStatus.SC_NOT_ACCEPTABLE);
+        this.checkErrorResponse(res.bodyAsJson(), "PR406-CM-0001");
     }
 
     /**

--- a/src/test/java/io/personium/test/jersey/cell/SignTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/SignTest.java
@@ -1,0 +1,101 @@
+package io.personium.test.jersey.cell;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.cxf.common.util.Base64Exception;
+import org.apache.cxf.common.util.Base64UrlUtility;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import io.personium.core.rs.PersoniumCoreApplication;
+import io.personium.test.categories.Integration;
+import io.personium.test.categories.Regression;
+import io.personium.test.categories.Unit;
+import io.personium.test.jersey.AbstractCase;
+import io.personium.test.setup.Setup;
+import io.personium.test.utils.SignUtils;
+import io.personium.test.utils.TResponse;
+
+/**
+ * Unit Test for SignResource with JerseyTestFramework
+ */
+@Category({Unit.class, Integration.class, Regression.class })
+public class SignTest extends AbstractCase {
+
+    /**
+     * Constructor
+     */
+    public SignTest() {
+        super(new PersoniumCoreApplication());
+    }
+
+    /**
+     * Function for checking JWS payload is match
+     */
+    private void checkContent(String strJWS, byte[] rawPayload) {
+        String[] strParts = strJWS.split("\\.");
+        if (strParts.length < 3) {
+            fail("Not a JWS: " + strJWS);
+        }
+        try {
+            assertArrayEquals(rawPayload, Base64UrlUtility.decode(strParts[1]));
+        } catch (Base64Exception e) {
+            e.printStackTrace();
+            fail("An exception is happend in decoding base64: " + strParts[1]);
+        }
+    }
+
+    /**
+     * Test that cell can sign a byte array
+     */
+    @Test
+    public void Test_that_cell_can_sign_bytes() {
+        byte[] testBody = "example_text".getBytes(StandardCharsets.UTF_8);
+        TResponse res = SignUtils.post(Setup.TEST_CELL1, MASTER_TOKEN_NAME, testBody, HttpStatus.SC_OK);
+        checkContent(res.getBody(), testBody);
+        System.out.println(res.getBody());
+    }
+
+    /**
+     * Test that cell can sign a zero-length string
+     */
+    @Test
+    public void Test_that_celL_can_sign_content_length_0() {
+        byte[] testBody = {};
+        TResponse res = SignUtils.post(Setup.TEST_CELL1, MASTER_TOKEN_NAME, testBody, HttpStatus.SC_OK);
+        checkContent(res.getBody(), testBody);
+    }
+
+    /**
+     * Test that cell reject request which accept header is not jose
+     */
+    @Test
+    public void Test_that_cell_reject_accept_is_not_jose() {
+        byte[] testBody = "example_text".getBytes(StandardCharsets.UTF_8);
+        SignUtils.post(Setup.TEST_CELL1, MASTER_TOKEN_NAME, "application/json", testBody, HttpStatus.SC_NOT_ACCEPTABLE);
+    }
+
+    /**
+     * Test that cell accept request which accept header is not specified
+     */
+    @Test
+    public void Test_that_cell_can_sign_accept_is_not_specified() {
+        byte[] testBody = "example_text".getBytes(StandardCharsets.UTF_8);
+        TResponse res = SignUtils.post(Setup.TEST_CELL1, MASTER_TOKEN_NAME, "", testBody, HttpStatus.SC_OK);
+        checkContent(res.getBody(), testBody);
+    }
+
+    /**
+     * Test that cell accept request which accept header is specified by wildcard
+     */
+    @Test
+    public void Test_that_cell_can_sign_accept_is_wildcard() {
+        byte[] testBody = "example_text".getBytes(StandardCharsets.UTF_8);
+        TResponse res = SignUtils.post(Setup.TEST_CELL1, MASTER_TOKEN_NAME, "*/*", testBody, HttpStatus.SC_OK);
+        checkContent(res.getBody(), testBody);
+    }
+}

--- a/src/test/java/io/personium/test/setup/Setup.java
+++ b/src/test/java/io/personium/test/setup/Setup.java
@@ -82,7 +82,7 @@ public class Setup extends AbstractCase {
     List<Config> confs = new ArrayList<Config>();
     List<Config> eventLogConfs = new ArrayList<Config>();
 
-    static final int NUM_ACCOUNTS = 31;
+    static final int NUM_ACCOUNTS = 32;
     static final int NUM_APP_AUTH_ACCOUNTS = 2;
     static final int NUM_ROLES = NUM_ACCOUNTS;
     static final int NUM_USERDATA = 10;

--- a/src/test/java/io/personium/test/utils/SignUtils.java
+++ b/src/test/java/io/personium/test/utils/SignUtils.java
@@ -17,6 +17,8 @@
  */
 package io.personium.test.utils;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Utility Class for using Sign API
  */
@@ -26,19 +28,54 @@ public class SignUtils {
 
     /**
      * Generate sign for content text
-     * @param token     token to be used
-     * @param text      text to be signed
-     * @param code      expected status code
-     * @param cellName  target cellName
+     * @param cellName target cellName
+     * @param token token to be used
+     * @param text text to be signed
+     * @param code expected status code
      * @return TResponse
      */
-    public static TResponse post(String token, String text, int code, String cellName) {
-        TResponse response = Http.request("cell/sign-post.txt")
-            .with("token", token)
-            .with("cellPath", cellName)
-            .with("textToBeSigned", text)
-            .returns()
-            .statusCode(code);
+    public static TResponse post(String cellName, String token, String text, int code) {
+        return post(cellName, token, "application/jose", text, code);
+    }
+
+    /**
+     * Generate sign for content text
+     * @param cellName target cellName
+     * @param token token to be used
+     * @param body byte array body to be signed
+     * @param code expected status code
+     * @return TResponse
+     */
+    public static TResponse post(String cellName, String token, byte[] body, int code) {
+        return post(cellName, token, "application/jose", body, code);
+    }
+
+    /**
+     * Generate sign for content text
+     * @param cellName target cellName
+     * @param token token to be used
+     * @param accept accept header
+     * @param text text to be signed
+     * @param code expected status code
+     * @return TResponse
+     */
+    public static TResponse post(String cellName, String token, String accept, String text, int code) {
+        return post(cellName, token, accept, text.getBytes(StandardCharsets.UTF_8), code);
+    }
+
+
+    /**
+     * Generate sign for content text
+     * @param cellName target cellName
+     * @param token token to be used
+     * @param accept accept header
+     * @param body byte array body to be signed
+     * @param code expected status code
+     * @return TResponse
+     */
+    public static TResponse post(String cellName, String token, String accept, byte[] body, int code) {
+        TResponse response = Http.request("cell/sign-post.txt").with("token", token).with("accept", accept)
+                .with("cellPath", cellName).setBodyBinary(body).returns().statusCode(code);
         return response;
     }
 }

--- a/src/test/java/io/personium/test/utils/SignUtils.java
+++ b/src/test/java/io/personium/test/utils/SignUtils.java
@@ -1,0 +1,44 @@
+/**
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.personium.test.utils;
+
+/**
+ * Utility Class for using Sign API
+ */
+public class SignUtils {
+    private SignUtils() {
+    }
+
+    /**
+     * Generate sign for content text
+     * @param token     token to be used
+     * @param text      text to be signed
+     * @param code      expected status code
+     * @param cellName  target cellName
+     * @return TResponse
+     */
+    public static TResponse post(String token, String text, int code, String cellName) {
+        TResponse response = Http.request("cell/sign-post.txt")
+            .with("token", token)
+            .with("cellPath", cellName)
+            .with("textToBeSigned", text)
+            .returns()
+            .statusCode(code);
+        return response;
+    }
+}

--- a/src/test/resources/personium-messages.properties
+++ b/src/test/resources/personium-messages.properties
@@ -371,6 +371,7 @@ io.personium.core.msg.PR400-CM-0002=Field [{0}] format error. Must be [{1}].
 io.personium.core.msg.PR400-CM-0003=Unknown key [{0}] specified.
 io.personium.core.msg.PR400-CM-0004=JSON parse error. [{0}].
 io.personium.core.msg.PR400-CM-0005=Invalid URL authority [{0}]. This unit is configured for URL authority [{1}]
+io.personium.core.msg.PR406-CM-0001=Requested media type [{0}] is not acceptable.
 
 io.personium.core.msg.PR409-CM-0001=Cell status is [import failed]. Only Unit Level's APIs, CellImport and GetToken are executable.
 io.personium.core.msg.PR409-CM-0002=Because [{0}] is being executed, writing to cell can not be done.

--- a/src/test/resources/request/cell/acl-authtest.txt
+++ b/src/test/resources/request/cell/acl-authtest.txt
@@ -171,4 +171,12 @@ Authorization: Bearer ${token}
             <D:privilege><p:log-read/></D:privilege>
         </D:grant>
     </D:ace>
+    <D:ace>
+        <D:principal>
+            <D:href>role31</D:href>
+        </D:principal>
+        <D:grant>
+            <D:privilege><p:sign/></D:privilege>
+        </D:grant>
+    </D:ace>
 </D:acl>

--- a/src/test/resources/request/cell/sign-post.txt
+++ b/src/test/resources/request/cell/sign-post.txt
@@ -1,0 +1,8 @@
+POST /${cellPath}/__sign HTTP/1.1
+Host: ?
+Content-Length: ?
+Connection: close
+Authorization: Bearer ${token}
+Accept: application/jose
+
+${textToBeSigned}

--- a/src/test/resources/request/cell/sign-post.txt
+++ b/src/test/resources/request/cell/sign-post.txt
@@ -3,6 +3,4 @@ Host: ?
 Content-Length: ?
 Connection: close
 Authorization: Bearer ${token}
-Accept: application/jose
-
-${textToBeSigned}
+Accept: ${accept}


### PR DESCRIPTION

## Implemented sign API

I implemented `SignResource` class to sign contents with private key which cell has.

The `sign` API has below features.

- The endpoint is `__sign`.
- The endpoint is executed with token having `p:sign` privilege.
- Response with Content-Type `application/jose` and contains a text formated JWS Compact Serialization .
- The JWS text can be verified with a key which can be fetch from `__certs` .

## Other changes

- Refactoring classes around private key of cell.
- Add some test classes for sign API.
- Add `p:sign` privilege.

Could you review this? 