### PR TITLE
Considering namespace while validating ACL

### DIFF
--- a/formatter.xml
+++ b/formatter.xml
@@ -9,7 +9,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>

--- a/src/main/java/io/personium/core/model/jaxb/Ace.java
+++ b/src/main/java/io/personium/core/model/jaxb/Ace.java
@@ -114,7 +114,7 @@ public final class Ace {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document doc;
         try {
-            String ns = "DAV:";
+            String ns = CommonUtils.XmlConst.NS_DAV;
             if (CellPrivilege.ROOT.getName().equals(privilege)) {
                 ns = CommonUtils.XmlConst.NS_PERSONIUM;
             }

--- a/src/main/java/io/personium/core/model/jaxb/Acl.java
+++ b/src/main/java/io/personium/core/model/jaxb/Acl.java
@@ -31,6 +31,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.namespace.QName;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -239,8 +240,8 @@ public final class Acl {
             if (ace.grant.privileges == null) {
                 throw PersoniumCoreException.Dav.XML_VALIDATE_ERROR.params("Can not read privilege");
             }
-            Map<String, CellPrivilege> cellPrivilegeMap = CellPrivilege.getPrivilegeMap();
-            Map<String, BoxPrivilege> boxPrivilegeMap = BoxPrivilege.getPrivilegeMap();
+            Map<QName, Privilege> cellPrivilegeMap = io.personium.core.model.jaxb.Privilege.cellPrivileges;
+            Map<QName, Privilege> boxPrivilegeMap = io.personium.core.model.jaxb.Privilege.boxPrivileges;
 
             for (io.personium.core.model.jaxb.Privilege privilege : ace.grant.privileges) {
                 // Privilege is not empty.
@@ -248,16 +249,16 @@ public final class Acl {
                     throw PersoniumCoreException.Dav.XML_VALIDATE_ERROR.params("Privilege is empty");
                 }
                 // This tag that can be set to privilege?
-                String localName = privilege.body.getLocalName();
+                QName qName = new QName(privilege.body.getNamespaceURI(), privilege.body.getLocalName());
                 if (isCellLevel) {
-                    if (!cellPrivilegeMap.containsKey(localName)
-                     && !boxPrivilegeMap.containsKey(localName)) {
-                        String cause = String.format("[%s] that can not be set in privilege", localName);
+                    if (!cellPrivilegeMap.containsKey(qName)
+                     && !boxPrivilegeMap.containsKey(qName)) {
+                        String cause = String.format("[%s] that can not be set in privilege", qName);
                         throw PersoniumCoreException.Dav.XML_VALIDATE_ERROR.params(cause);
                     }
                 } else {
-                    if (!boxPrivilegeMap.containsKey(localName)) {
-                        String cause = String.format("[%s] that can not be set in privilege", localName);
+                    if (!boxPrivilegeMap.containsKey(qName)) {
+                        String cause = String.format("[%s] that can not be set in privilege", qName);
                         throw PersoniumCoreException.Dav.XML_VALIDATE_ERROR.params(cause);
                     }
                 }

--- a/src/main/java/io/personium/core/model/jaxb/Acl.java
+++ b/src/main/java/io/personium/core/model/jaxb/Acl.java
@@ -41,8 +41,6 @@ import io.personium.common.auth.token.Role;
 import io.personium.common.utils.CommonUtils;
 import io.personium.core.PersoniumCoreException;
 import io.personium.core.auth.AccessContext;
-import io.personium.core.auth.BoxPrivilege;
-import io.personium.core.auth.CellPrivilege;
 import io.personium.core.auth.OAuth2Helper;
 import io.personium.core.auth.Privilege;
 import io.personium.core.utils.UriUtils;

--- a/src/main/java/io/personium/core/model/jaxb/Privilege.java
+++ b/src/main/java/io/personium/core/model/jaxb/Privilege.java
@@ -17,12 +17,20 @@
  */
 package io.personium.core.model.jaxb;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
 import org.w3c.dom.Element;
+
+import io.personium.common.utils.CommonUtils.XmlConst;
+import io.personium.core.auth.BoxPrivilege;
+import io.personium.core.auth.CellPrivilege;
 
 /**
  * D: JAXB object corresponding to the privilege tag.
@@ -30,6 +38,30 @@ import org.w3c.dom.Element;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(namespace = "DAV:", name = "privilege")
 public final class Privilege {
+
+    /** CellPrivilege map with QName key */
+    public static Map<QName, io.personium.core.auth.Privilege> cellPrivileges;
+
+    /** BoxPrivilege map with QName key */
+    public static Map<QName, io.personium.core.auth.Privilege> boxPrivileges;
+
+    static {
+        // initialize maps
+        cellPrivileges = new HashMap<QName, io.personium.core.auth.Privilege>();
+        CellPrivilege.getPrivilegeMap().forEach((name, priv) -> {
+            cellPrivileges.put(new QName(XmlConst.NS_PERSONIUM, name), priv);
+        });
+
+        boxPrivileges = new HashMap<QName, io.personium.core.auth.Privilege>();
+        BoxPrivilege.getPrivilegeMap().forEach((name, priv) -> {
+            if (name.equals("exec") || name.equals("stream-send") || name.equals("stream-receive")) {
+                boxPrivileges.put(new QName(XmlConst.NS_PERSONIUM, name), priv);
+            } else {
+                boxPrivileges.put(new QName(XmlConst.NS_DAV, name), priv);
+            }
+        });
+    }
+
     @XmlAnyElement
     Element body;
 

--- a/src/test/java/io/personium/core/model/jaxb/AclTest.java
+++ b/src/test/java/io/personium/core/model/jaxb/AclTest.java
@@ -631,7 +631,37 @@ public class AclTest {
             fail("Not throws exception.");
         } catch (PersoniumCoreException e) {
             PersoniumCoreException expected = PersoniumCoreException.Dav.XML_VALIDATE_ERROR.params(
-                    "[test] that can not be set in privilege");
+                    "[{DAV:}test] that can not be set in privilege");
+            assertEquals(expected.getCode(), e.getCode());
+            assertEquals(expected.getMessage(), e.getMessage());
+        }
+    }
+
+    /**
+     * Test that validateAcl function refuses privilege specified not valid namespace.
+     * Related Issue: https://github.com/personium/personium-core/issues/64
+     * @throws IOException
+     * @throws JAXBException
+     */
+    @Test
+    public void validateAcl_aclString_with_errorneous_namespace_throws_exception() throws IOException, JAXBException {
+        String aclString = "<D:acl xmlns:D='DAV:' xml:base='https://fqdn/aclTest/__role/__/'>"
+                + "<D:ace>" 
+                + "<D:principal><D:all/></D:principal>"
+                + "<D:grant>"
+                + "<D:privilege><p:read xmlns:p='urn:x-personium:xmlns'/></D:privilege>"
+                + "</D:grant>"
+                + "</D:ace>"
+                + "</D:acl>";
+        Acl aclToSet = null;
+
+        try (Reader reader = new StringReader(aclString)) {
+            aclToSet = ObjectIo.unmarshal(reader, Acl.class);
+            aclToSet.validateAcl(true);
+            fail("No exceptions thrown");
+        } catch (PersoniumCoreException e) {
+            PersoniumCoreException expected = PersoniumCoreException.Dav.XML_VALIDATE_ERROR.params(
+                "[{urn:x-personium:xmlns}read] that can not be set in privilege");
             assertEquals(expected.getCode(), e.getCode());
             assertEquals(expected.getMessage(), e.getMessage());
         }
@@ -644,14 +674,14 @@ public class AclTest {
      */
     @Test
     public void CellレベルのACLのバリデートでprivilegeの項目に許可するPrivilegeを指定した場合() throws IOException, JAXBException {
-        String aclString = "<D:acl xmlns:D='DAV:' xml:base='https://fqdn/aclTest/__role/__/'>"
+        String aclString = "<D:acl xmlns:D='DAV:' xmlns:p='urn:x-personium:xmlns' xml:base='https://fqdn/aclTest/__role/__/'>"
                 + "<D:ace>"
                 + "<D:principal>"
                 + "<D:all/>"
                 + "</D:principal>"
                 + "<D:grant>"
                 + "<D:privilege>"
-                + "<D:auth-read/>"
+                + "<p:auth-read/>"
                 + "</D:privilege>"
                 + "</D:grant>"
                 + "</D:ace>"
@@ -691,7 +721,7 @@ public class AclTest {
             fail("Not throws exception.");
         } catch (PersoniumCoreException e) {
             PersoniumCoreException expected = PersoniumCoreException.Dav.XML_VALIDATE_ERROR.params(
-                    "[test] that can not be set in privilege");
+                    "[{DAV:}test] that can not be set in privilege");
             assertEquals(expected.getCode(), e.getCode());
             assertEquals(expected.getMessage(), e.getMessage());
         }

--- a/src/test/java/io/personium/core/model/jaxb/ObjectIoTest.java
+++ b/src/test/java/io/personium/core/model/jaxb/ObjectIoTest.java
@@ -147,7 +147,7 @@ public class ObjectIoTest {
         assertEquals("public", requiredSchemaAuthz);
 
         // Number of ACE's
-        String roleHref = xpath.evaluate("count(//ace)", result);
+        String roleHref = xpath.evaluate("count(//*[local-name()='ace'])", result);
         assertEquals("2", roleHref);
     }
 


### PR DESCRIPTION

By using QName to match privilege from privileve map, specified privileges are validated correctly.

Closes #64 