### PR TITLE
replace `org.junit.Assert.assertThat` with `org.hamcrest.CoreMatchers.assertThat`

### DIFF
--- a/src/main/java/io/personium/core/model/DavCommon.java
+++ b/src/main/java/io/personium/core/model/DavCommon.java
@@ -31,7 +31,7 @@ public class DavCommon {
     /** Resource minimum length.*/
     private static final int MIN_RESOURCE_LENGTH = 1;
     /** Maximum resource length.*/
-    private static final int MAX_RESOURCE_LENGTH = 256;
+    private static final int MAX_RESOURCE_LENGTH = 255;
 
     /** Default value of Depth header.*/
     public static final String DEPTH_INFINITY = "infinity";

--- a/src/test/java/io/personium/core/model/ModelFactoryTest.java
+++ b/src/test/java/io/personium/core/model/ModelFactoryTest.java
@@ -18,7 +18,7 @@
 package io.personium.core.model;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/src/test/java/io/personium/core/rs/cell/CellCtlResourceTest.java
+++ b/src/test/java/io/personium/core/rs/cell/CellCtlResourceTest.java
@@ -16,7 +16,7 @@
  */
 package io.personium.core.rs.cell;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
 import static org.powermock.api.mockito.PowerMockito.doReturn;

--- a/src/test/java/io/personium/core/rule/action/ActionUtilsTest.java
+++ b/src/test/java/io/personium/core/rule/action/ActionUtilsTest.java
@@ -17,7 +17,7 @@
 package io.personium.core.rule.action;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/src/test/java/io/personium/core/rule/action/ExecActionTest.java
+++ b/src/test/java/io/personium/core/rule/action/ExecActionTest.java
@@ -17,7 +17,7 @@
 package io.personium.core.rule.action;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 

--- a/src/test/java/io/personium/core/rule/action/RelayActionTest.java
+++ b/src/test/java/io/personium/core/rule/action/RelayActionTest.java
@@ -17,7 +17,7 @@
 package io.personium.core.rule.action;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
 

--- a/src/test/java/io/personium/core/rule/action/RelayEventActionTest.java
+++ b/src/test/java/io/personium/core/rule/action/RelayEventActionTest.java
@@ -17,7 +17,7 @@
 package io.personium.core.rule.action;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
 

--- a/src/test/java/io/personium/core/utils/PersoniumUrlTest.java
+++ b/src/test/java/io/personium/core/utils/PersoniumUrlTest.java
@@ -1,10 +1,26 @@
+/**
+ * Personium
+ * Copyright 2018-2022 Personium Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.personium.core.utils;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/io/personium/core/utils/PersoniumUrlTest_PathBasedTest.java
+++ b/src/test/java/io/personium/core/utils/PersoniumUrlTest_PathBasedTest.java
@@ -1,7 +1,23 @@
+/**
+ * Personium
+ * Copyright 2018-2022 Personium Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.personium.core.utils;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/src/test/java/io/personium/test/jersey/cell/ctl/BoxBulkDeletionTest.java
+++ b/src/test/java/io/personium/test/jersey/cell/ctl/BoxBulkDeletionTest.java
@@ -17,7 +17,7 @@
 package io.personium.test.jersey.cell.ctl;
 
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;


### PR DESCRIPTION

The method assertThat(Long, Matcher<? super Long>) from the type Assert is deprecated